### PR TITLE
docs: fix typo on principles page

### DIFF
--- a/principles.html
+++ b/principles.html
@@ -112,7 +112,7 @@
                                 The 8 principles of responsible ML development provide a practical framework to support technologists when designing, developing or maintaining systems that learn from data.
                                 <br>
                                 <br>
-                                If these principles resonate with you, you invite you to join the <a href="index.html#contact">Ethical ML Network (BETA)</a>, and be part of a global network of leaders driving forward positive change in this area.
+                                If these principles resonate with you, we invite you to join the <a href="index.html#contact">Ethical ML Network (BETA)</a>, and be part of a global network of leaders driving forward positive change in this area.
                             </p>
 						</header>
                     <br>


### PR DESCRIPTION
Hi there! I'm excited to have discovered this project via @hangtwenty's https://github.com/hangtwenty/dive-into-machine-learning repo.

This little PR fixes a typo.