### PR TITLE
Convert relative links to absolute to fix newsletter navigation

### DIFF
--- a/mle/170.html
+++ b/mle/170.html
@@ -13,7 +13,7 @@
         <meta name="author" content="The Institute for Ethical Ai & Machine Learning">
         <meta name="description" content="The Institute for Ethical AI & Machine Learning is a UK based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.">
         <link rel="canonical" href="https://ethical.institute">
-        <link rel="icon" href="images/logos/eml-logo-white.png">
+        <link rel="icon" href="/images/logos/eml-logo-white.png">
 
 
 		<!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
@@ -64,32 +64,32 @@
 
 			<!-- Header -->
 				<header id="header">
-                    <h1 id="logo"><a href="index.html"><img src="../images/logos/eml-logo-white.png" height="15px"> The Institute for Ethical AI & Machine Learning</a></h1>
+                    <h1 id="logo"><a href="/index.html"><img src="../images/logos/eml-logo-white.png" height="15px"> The Institute for Ethical AI & Machine Learning</a></h1>
 					<nav id="nav">
 						<ul style="font-weight: bold">
-							<li><a href="index.html">Home</a></li>
+							<li><a href="/index.html">Home</a></li>
 							<li>
                                 <a>Principles ▾</a>
                                 <ul>
-                                    <li><a href="principles.html">Principles Overview</a></li>
-                                    <li><a href="principles.html#commitment-1">#1 Human Augmentation</a></li>
-                                    <li><a href="principles.html#commitment-2">#2 Bias Evaluation</a></li>
-                                    <li><a href="principles.html#commitment-3">#3 Explainability</a></li>
-                                    <li><a href="principles.html#commitment-4">#4 Reproducible Operations</a></li>
-                                    <li><a href="principles.html#commitment-5">#5 Displacement Strategy</a></li>
-                                    <li><a href="principles.html#commitment-6">#6 Practical Accuracy</a></li>
-                                    <li><a href="principles.html#commitment-7">#7 Trust by Privacy</a></li>
-                                    <li><a href="principles.html#commitment-8">#8 Security Risks</a></li>
+                                    <li><a href="/principles.html">Principles Overview</a></li>
+                                    <li><a href="/principles.html#commitment-1">#1 Human Augmentation</a></li>
+                                    <li><a href="/principles.html#commitment-2">#2 Bias Evaluation</a></li>
+                                    <li><a href="/principles.html#commitment-3">#3 Explainability</a></li>
+                                    <li><a href="/principles.html#commitment-4">#4 Reproducible Operations</a></li>
+                                    <li><a href="/principles.html#commitment-5">#5 Displacement Strategy</a></li>
+                                    <li><a href="/principles.html#commitment-6">#6 Practical Accuracy</a></li>
+                                    <li><a href="/principles.html#commitment-7">#7 Trust by Privacy</a></li>
+                                    <li><a href="/principles.html#commitment-8">#8 Security Risks</a></li>
                                 </ul>
                             </li>
                             <li>
                                 <a>Institute Initiatives ▾</a>
                                 <ul>
-                                    <li><a href="principles.html">Responsible ML Principles</a></li>
-                                    <li><a href="rfx.html">AI Procurement Framework</a></li>
-                                    <li><a href="xai.html">AI Explainability Framework</a></li>
-                                    <li><a href="mle.html">Newsletter</a></li>
-                                    <li><a href="network.html">Volunteers Network</a></li>
+                                    <li><a href="/principles.html">Responsible ML Principles</a></li>
+                                    <li><a href="/rfx.html">AI Procurement Framework</a></li>
+                                    <li><a href="/xai.html">AI Explainability Framework</a></li>
+                                    <li><a href="/mle.html">Newsletter</a></li>
+                                    <li><a href="/network.html">Volunteers Network</a></li>
                                     <li><a href="https://github.com/EthicalML/awesome-machine-learning-operations" target="_blank">Machine Learning OSS Ecosystem</a></li>
                                     <li><a href="https://lfaidata.foundation/blog/2021/08/26/kompute-joins-lf-ai-data-as-new-sandbox-project/" target="_blank">Cross-vendor GPU Computing</a></li>
                                     <li><a href="https://lfaidata.foundation/blog/2019/10/09/the-institute-for-ethical-ai-and-machine-learning-joins-lf-ai/" target="_blank">Linux Foundation Contributions</a></li>
@@ -98,11 +98,11 @@
                                 </ul>
                             </li>
                             <li>
-                                <a href="mle.html">Newsletter</a>
+                                <a href="/mle.html">Newsletter</a>
                             </li>
 	
                             </li>
-							<li><a href="index.html#contact" class="button special">Contact us or Join</a></li>
+							<li><a href="/index.html#contact" class="button special">Contact us or Join</a></li>
 						</ul>
 					</nav>
 				</header>


### PR DESCRIPTION
There is an issue with the navigation on the newsletter page. if you go to the newsletter, e.g. the last one 
https://ethical.institute/mle/170.html
and then click any link in the menu, you get 404. That's because we are in `/mle/` subfolder, and all the links in the menu are relative, e.g. `href="principles.html"`. When you click that, you get `/mle/principles.html` - address that clearly does not exist.

One way to fix that is to use addresses relative to the website root, which means just adding a slash in front: `href="/principles.html"`. This PR illustrates that with the most recent newsletter.

Previous newsletter issues have the same problem, but given that they are a thing in the past not sure how important it is to apply this fix to them.