### PR TITLE
content: rebrand to The Institute for Ethical AI Alignment & Safety

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,9 +4,9 @@ Context for AI coding agents editing this repository. Read this before touching 
 
 ## What this repo is
 
-The live website for **The Institute for Ethical AI & Machine Learning** (domain: `ethical.institute`, see `CNAME`). It is a **Jekyll** static site served via **GitHub Pages**. There is no custom backend; forms post to third-party endpoints loaded by JS.
+The live website for **The Institute for Ethical AI Alignment & Safety** (domain: `ethical.institute`, see `CNAME`). It is a **Jekyll** static site served via **GitHub Pages**. There is no custom backend; forms post to third-party endpoints loaded by JS.
 
-> **Rebrand in progress.** The organisation is being repositioned from *"The Institute for Ethical AI & Machine Learning"* to *"The Institute for Ethical AI Alignment & Safety"*. When editing copy, prefer the new positioning (AI alignment & safety) over the legacy "responsible ML / MLOps / procurement" framing, but keep changes consistent site-wide — the name appears in many places (navbar, footer, every page's front-matter `title`/`description`, README). Do not rename half the site. See `tmp/rebrand-content-review.md` (git-ignored working doc) for the full content plan if present.
+The site positions the organisation around **AI alignment & safety**. When editing copy, keep this framing and apply the org name consistently site-wide — it appears in many places (navbar, footer, every page's front-matter `title`/`description`, README). Do not rename half the site.
 
 ## Tech + structure
 
@@ -23,35 +23,35 @@ The live website for **The Institute for Ethical AI & Machine Learning** (domain
 
 ## Page inventory (root `.html`)
 
-| Page | Purpose | Key legacy terms to watch |
-|------|---------|---------------------------|
-| `index.html` | Homepage: mission, 4-phase strategy, 8 principles summary, AI-RFX, network CTA | "Europe-based research centre", "8 principles", "4 phases" |
-| `principles.html` | The 8 Responsible ML Principles (full detail + case studies) | Principle #8 title is inconsistent ("Security risks" vs "Data risk awareness") |
-| `security.html` | **MLSecOps Top 10** initiative | OWASP mapping table |
-| `xai.html` | **XAI** eXplainable AI Framework (ALPHA) | |
-| `eal.html` | **Ethically Aligned (Software) Licenses** | |
-| `rfx.html` | **AI-RFX Procurement Framework** landing | |
-| `rfp.html` | AI Request for Proposal template (long-form doc) | |
-| `mlmm.html` | Machine Learning Maturity Model (long-form doc) | |
-| `network.html` | Ethical (M)L Network members list + join | "(BETA)" appears repeatedly |
-| `contact.html` | Just includes header/navbar/apply-form/footer | |
+| Page | Purpose |
+|------|---------|
+| `index.html` | Homepage: mission, 4-phase strategy, 9 principles summary, AI-RFX, network CTA |
+| `principles.html` | The 9 Responsible AI Principles (full detail + case studies) |
+| `security.html` | **MLSecOps Top 10** initiative (OWASP mapping table) |
+| `xai.html` | **XAI** eXplainable AI Framework (ALPHA) |
+| `eal.html` | **Ethically Aligned (Software) Licenses** |
+| `rfx.html` | **AI-RFX Procurement Framework** landing |
+| `rfp.html` | AI Request for Proposal template (long-form doc) |
+| `mlmm.html` | Machine Learning Maturity Model (long-form doc) |
+| `network.html` | Ethical AI Network members list + join |
+| `contact.html` | Just includes header/navbar/apply-form/footer |
 | `state-of-ml-2024.html` / `state-of-ml-2025.html` | Survey report visualisations (Chart.js + CSV) | data in `data.csv`, `data-2025.csv` |
 | `mle.html` | Newsletter landing | |
 | `privacypolicy.html` | Privacy policy | |
 
 ## Terminology (canonical — use consistently)
 
-Legacy copy mixes several names for the same things. When editing, converge on ONE form per concept and apply site-wide:
-- Organisation: **The Institute for Ethical AI & Machine Learning** → (target) **The Institute for Ethical AI Alignment & Safety**.
-- Network: currently "Ethical AI Network" / "Ethical ML Network (BETA)" used interchangeably — pick one; consider dropping "(BETA)".
-- Principles: "8 Machine Learning Principles" / "8 Principles for Responsible ML" / "The Responsible Machine Learning Principles" — pick one.
+Use ONE canonical form per concept and apply it site-wide:
+- Organisation: **The Institute for Ethical AI Alignment & Safety**.
+- Network: **Ethical AI Network** (no "(BETA)").
+- Principles: **The 9 Responsible AI Principles**.
 - Strategy: "4 phases towards responsible development of AI" (By Principle / By Process / By Standards / By Regulation).
 
 ## Conventions
 
 - **Markdown files**: do NOT hard-wrap lines — let prose overflow (per repo/user convention).
 - **HTML copy edits**: change only the text nodes; leave classes, structure, and Liquid tags intact. Grep for a phrase before editing — the same string often appears on multiple pages and in the navbar/footer.
-- Front-matter `title` and `description` are the SEO/social text for each page — update them when rebranding.
+- Front-matter `title` and `description` are the SEO/social text for each page — keep them in sync when you change a page's headline copy.
 - Fix-on-sight typos present in legacy copy: `togethers`, `devleopment`/`development` inconsistency, `rramework`, `Learnign`, `tempalte`, `prision`, `carefuly`, `identifie`.
 
 ## Token-efficiency rules for agents

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,65 @@
+# Copilot / Agent Instructions — The Institute for Ethical AI website
+
+Context for AI coding agents editing this repository. Read this before touching any page. Keep changes **simple and surgical** — this is a small, hand-maintained static site, not an app. Do not introduce build tooling, frameworks, or abstractions unless explicitly asked.
+
+## What this repo is
+
+The live website for **The Institute for Ethical AI & Machine Learning** (domain: `ethical.institute`, see `CNAME`). It is a **Jekyll** static site served via **GitHub Pages**. There is no custom backend; forms post to third-party endpoints loaded by JS.
+
+> **Rebrand in progress.** The organisation is being repositioned from *"The Institute for Ethical AI & Machine Learning"* to *"The Institute for Ethical AI Alignment & Safety"*. When editing copy, prefer the new positioning (AI alignment & safety) over the legacy "responsible ML / MLOps / procurement" framing, but keep changes consistent site-wide — the name appears in many places (navbar, footer, every page's front-matter `title`/`description`, README). Do not rename half the site. See `tmp/rebrand-content-review.md` (git-ignored working doc) for the full content plan if present.
+
+## Tech + structure
+
+- **Jekyll**: pages are `.html` files at the repo root with YAML front-matter (`title`, `description`, optional `image-banner`, `no-bootstrap`). Liquid `{% include %}` pulls in shared partials.
+- **No `_layouts` / `_config.yml` / `_data`**: pages are self-contained and stitch partials manually via includes. Do not assume a standard Jekyll layout chain.
+- **Shared partials** live in `_includes/`:
+  - `navbar.html` — top navigation (org name, Principles menu, Institute Initiatives menu, Contact). **The single source of truth for the site menu.**
+  - `header.html` — `<head>` boilerplate; conditional Bootstrap via `page.no-bootstrap`.
+  - `footer.html` — social links + copyright (org name appears here).
+  - `apply-form.html` — the "Contact us or join" form block, included at the bottom of most pages.
+  - `subscribe-form.html` — newsletter subscribe block.
+- `assets/` — CSS/JS (incl. Chart.js survey logic in `assets/js/state-of-ml-*.js`), `images/`.
+- `replace_partials.sh` — helper that was used to extract inline blocks into `_includes/`. Historical; understand before rerunning.
+
+## Page inventory (root `.html`)
+
+| Page | Purpose | Key legacy terms to watch |
+|------|---------|---------------------------|
+| `index.html` | Homepage: mission, 4-phase strategy, 8 principles summary, AI-RFX, network CTA | "Europe-based research centre", "8 principles", "4 phases" |
+| `principles.html` | The 8 Responsible ML Principles (full detail + case studies) | Principle #8 title is inconsistent ("Security risks" vs "Data risk awareness") |
+| `security.html` | **MLSecOps Top 10** initiative | OWASP mapping table |
+| `xai.html` | **XAI** eXplainable AI Framework (ALPHA) | |
+| `eal.html` | **Ethically Aligned (Software) Licenses** | |
+| `rfx.html` | **AI-RFX Procurement Framework** landing | |
+| `rfp.html` | AI Request for Proposal template (long-form doc) | |
+| `mlmm.html` | Machine Learning Maturity Model (long-form doc) | |
+| `network.html` | Ethical (M)L Network members list + join | "(BETA)" appears repeatedly |
+| `contact.html` | Just includes header/navbar/apply-form/footer | |
+| `state-of-ml-2024.html` / `state-of-ml-2025.html` | Survey report visualisations (Chart.js + CSV) | data in `data.csv`, `data-2025.csv` |
+| `mle.html` | Newsletter landing | |
+| `privacypolicy.html` | Privacy policy | |
+
+## Terminology (canonical — use consistently)
+
+Legacy copy mixes several names for the same things. When editing, converge on ONE form per concept and apply site-wide:
+- Organisation: **The Institute for Ethical AI & Machine Learning** → (target) **The Institute for Ethical AI Alignment & Safety**.
+- Network: currently "Ethical AI Network" / "Ethical ML Network (BETA)" used interchangeably — pick one; consider dropping "(BETA)".
+- Principles: "8 Machine Learning Principles" / "8 Principles for Responsible ML" / "The Responsible Machine Learning Principles" — pick one.
+- Strategy: "4 phases towards responsible development of AI" (By Principle / By Process / By Standards / By Regulation).
+
+## Conventions
+
+- **Markdown files**: do NOT hard-wrap lines — let prose overflow (per repo/user convention).
+- **HTML copy edits**: change only the text nodes; leave classes, structure, and Liquid tags intact. Grep for a phrase before editing — the same string often appears on multiple pages and in the navbar/footer.
+- Front-matter `title` and `description` are the SEO/social text for each page — update them when rebranding.
+- Fix-on-sight typos present in legacy copy: `togethers`, `devleopment`/`development` inconsistency, `rramework`, `Learnign`, `tempalte`, `prision`, `carefuly`, `identifie`.
+
+## Token-efficiency rules for agents
+
+- **Do NOT read `mle/*`** — it is the newsletter archive (huge, low value). Also skip `_site/` (generated output) and `blog`/`resources` bulk content unless the task is specifically about them.
+- HTML pages are token-heavy. To review **copy**, extract visible text first (strip `<script>`/`<style>`/tags) rather than reading raw HTML. Read raw HTML only when you must edit structure/markup.
+- Survey CSVs (`data.csv`, `data-2025.csv`) are large — sample, don't read whole.
+
+## Local dev
+
+Standard Jekyll: `bundle install` then `bundle exec jekyll serve` (uses `Gemfile`). Output goes to `_site/` (git-ignored). Commits should be comprehensive; do not append session URLs to commit messages or PR bodies.

--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,8 @@ tags.*
 Gemfile.lock
 _site/
 
+# Working / scratch files
+tmp/
+
 .claude
 CLAUDE.md

--- a/_includes/apply-form.html
+++ b/_includes/apply-form.html
@@ -2,9 +2,8 @@
             <section id="five" class="wrapper style2 special" style="padding: 3em 0 0 0">
                 <div id="contact" class="">
                     <header>
-                        <h2>Contact us or join the Ethical ML Network (BETA)</h2>
+                        <h2>Contact us or join the Ethical AI Network</h2>
                     </header>
                     <iframe class="6u 8u(medium) 12u$(xsmall)" style="height: 80vh;" src="https://docs.google.com/forms/d/e/1FAIpQLScLmKLxQ8s5nv1xlgID08xPEhlcaigWBGg1qUU1hozqXG2v-w/viewform?embedded=true" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
                 </div>
             </section>
-

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
                         <li><a href="mailto:a@ethical.institute" class="icon fa-envelope"><span class="label">Email</span></a></li>
 					</ul>
 					<ul class="copyright">
-						<li>&copy; The Institute for Ethical AI & ML. 
+						<li>&copy; The Institute for Ethical AI Alignment & Safety.
                             All rights reserved.</li>
 					</ul>
 				</footer>
@@ -40,4 +40,3 @@
 	<script src="/assets/js/CanvasRenderer.js"></script>
 	<script src="/assets/js/stats.min.js"></script>
 	<script src="/assets/js/main.js"></script>
-

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
 <!-- FACEBOOK -->
 <meta property="og:type" content="website">
 <meta property="og:title" content="{{ page.title }}">
-<meta property="og:description" content="The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.">
+<meta property="og:description" content="The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.">
 <meta property="og:image" content="{% if page.image-banner != nil %}{{ page.image-banner }}{% else %}https://ethical.institute/images/principles.jpg{% endif %}">
 
 <!-- THE TWITTER -->
@@ -24,7 +24,7 @@
 
 
 <!-- G++ -->
-<meta itemprop="name" content="The Institute for Ethical AI & Machine Learning">
+<meta itemprop="name" content="The Institute for Ethical AI Alignment & Safety">
 <meta itemprop="description" content="{{ page.title }}">
 <meta itemprop="image" content="{% if page.image-banner != nil %}{{ page.image-banner }}{% else %}https://ethical.institute/images/principles.jpg{% endif %}">
 
@@ -40,4 +40,3 @@
 <link rel="stylesheet" href="/assets/css/main.css" />
 <!--[if lte IE 9]><link rel="stylesheet" href="/assets/css/ie9.css" /><![endif]-->
 <!--[if lte IE 8]><link rel="stylesheet" href="/assets/css/ie8.css" /><![endif]-->
-

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="google-site-verification" content="9rfgBQEvfnZ7HS_kBzINrlrJ-_sJcyJxqEUltqvP9Og" />
-<meta name="author" content="The Institute for Ethical Ai & Machine Learning">
+<meta name="author" content="The Institute for Ethical AI Alignment & Safety">
 <link rel="icon" href="/images/logos/eml-logo-white.png">
 
 <title>{{ page.title }}</title>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,6 @@
 <!-- Header -->
 	<header id="header">
-		<h1 id="logo"><a href="/index.html"><img src="/images/logos/eml-logo-white.png" height="15px"></a><a class="d-lg-inline-block d-none" href="/index.html">&nbsp;The Institute for Ethical AI & Machine Learning</a></h1>
+		<h1 id="logo"><a href="/index.html"><img src="/images/logos/eml-logo-white.png" height="15px"></a><a class="d-lg-inline-block d-none" href="/index.html">&nbsp;The Institute for Ethical AI Alignment & Safety</a></h1>
 		<nav id="nav">
 			<ul style="font-weight: bold">
 				<li>
@@ -50,4 +50,3 @@
 			</ul>
 		</nav>
 	</header>
-

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -14,7 +14,7 @@
 						<li><a href="/principles.html#commitment-5">#5 Displacement Strategy</a></li>
 						<li><a href="/principles.html#commitment-6">#6 Practical Accuracy</a></li>
 						<li><a href="/principles.html#commitment-7">#7 Trust by Privacy</a></li>
-						<li><a href="/principles.html#commitment-8">#8 Security Risks</a></li>
+						<li><a href="/principles.html#commitment-8">#8 Security & Data Risk</a></li>
 					</ul>
 				</li>
 				<li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -15,12 +15,13 @@
 						<li><a href="/principles.html#commitment-6">#6 Practical Accuracy</a></li>
 						<li><a href="/principles.html#commitment-7">#7 Trust by Privacy</a></li>
 						<li><a href="/principles.html#commitment-8">#8 Security & Data Risk</a></li>
+						<li><a href="/principles.html#commitment-9">#9 Alignment with Intent</a></li>
 					</ul>
 				</li>
 				<li>
 					<a>Institute Initiatives ▾</a>
 					<ul>
-						<li><a href="/principles.html">Responsible ML Principles</a></li>
+						<li><a href="/principles.html">Responsible AI Principles</a></li>
 						<li><a href="/security.html">MLSecOps Top 10</a></li>
 						<li><a href="/rfx.html">AI Procurement Framework</a></li>
 						<li><a href="/xai.html">AI Explainability Framework</a></li>

--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>

--- a/eal.html
+++ b/eal.html
@@ -42,7 +42,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 Ethically Aligned Software Licenses
                             </h2>
                             <h3>
-                                Ensure your open source code is used reponsibly by requiring a commitment into proven professional and ethical standards.
+                                Ensure your open source code is used responsibly by requiring a commitment into proven professional and ethical standards.
                                 <br>
                                 <br>
                                 Join the movement and help raise the bar for the use of technology in critical applications by design.
@@ -74,7 +74,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 								<!-- Content -->
 									<section id="content">
 										<h3>Responsible Development by Design</h3>
-										<p>We believe that every technologist has the ability to make a massive difference one line of code at a time. Ensuring ethical design is as easy as including the <a href="https://github.com/EthicalML/licenses">ethically aligned software license</a> in your code which includes the normal copyright, plus a requirement of users to commit on a specific ethical and/or professional framework. We currently support the <a href="https://github.com/EthicalML/ethically-aligned-licenses/blob/master/LICENSE_EA_MIT">APACHE</a> and <a href="https://github.com/EthicalML/ethically-aligned-licenses/blob/master/LICENSE_EA_MIT">MIT</a> Licenses, and we are working to expand our work to include the Mozilla, GNU, LGPL and more.</p>
+										<p>We believe that every technologist has the ability to make a massive difference one line of code at a time. Ensuring ethical design is as easy as including the <a href="https://github.com/EthicalML/licenses">ethically aligned software license</a> in your code which includes the normal copyright, plus a requirement of users to commit on a specific ethical and/or professional framework. We currently support the <a href="https://github.com/EthicalML/ethically-aligned-licenses/blob/master/LICENSE_EA_MIT">APACHE</a> and <a href="https://github.com/EthicalML/ethically-aligned-licenses/blob/master/LICENSE_EA_MIT">MIT</a> Licenses, and we are working to expand our work to include the Mozilla, GNU, LGPL and more. The same approach applies to the responsible release of open models and model weights.</p>
                                         <img src="images/git-shot.jpg" style="width: 100%">
 
                                         <br><br>

--- a/eal.html
+++ b/eal.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>

--- a/index.html
+++ b/index.html
@@ -21,10 +21,10 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 						<header style="font-weight: bold">
 							<h2>The Institute for Ethical AI Alignment & Safety</h2>
                             <p  style="max-width: 850px">
-                                The Institute for Ethical AI Alignment & Safety is a Europe-based research centre that develops frameworks that support the responsible development, deployment and operation of machine learning systems.
+                                The Institute for Ethical AI Alignment & Safety develops practical, open-source frameworks for building AI systems that are safe, aligned with human intent, and accountable — from classical ML to frontier models and autonomous agents.
                                 <br>
                                 <br>
-                                We are formed by cross functional <a href="network.html">teams of volunteers</a> including leaders in technology, machine learning, industry, policy and academia (STEM, Humanities and Social Sciences).
+                                We are a cross-functional community of <a href="network.html">volunteers</a> spanning technology, ML research, industry, policy and academia.
                             </p>
 						</header>
                     <br>
@@ -38,7 +38,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 					<div class="content" style="text-align: center">
                         <header class="major">
                             <h2>
-                                We have a commitment to advocate for the responsible development of AI
+                                We advocate for the safe and aligned development of AI
                             </h2>
                             <h3>
                                 We are a research centre that carries out highly-technical, practical and cross-functional research across <a href="#principles">the 9 Responsible AI Principles</a>.

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                         <br>
                         <br>
                         <br>
-                        <h2>Learn more about the <a href="#principles">8 principles below</a>, or join <a href="#contact">the Ethical ML Network (BETA)</a>.</h2>
+                        <h2>Learn more about the <a href="#principles">8 principles below</a>, or join <a href="#contact">the Ethical AI Network</a>.</h2>
 
                     </div>
                 </section>
@@ -255,8 +255,8 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 </div>
                                 <div id="network" class="8u$ 12u$(medium) important(medium)">
                                     <section id="content">
-                                        <h3 id="network">Apply to join the Ethical ML Network (BETA)</h3>
-                                        <p>The Ethical ML Network (BETA) is a global network of diverse engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 8 principles for responsible development of machine learning</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. The network is currently on BETA, so if you want to join you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
+                                        <h3 id="network">Apply to join the Ethical AI Network</h3>
+                                        <p>The Ethical AI Network is a global network of diverse engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 8 principles for responsible development of machine learning</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. If you'd like to join, you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
                                         <ul>
                                             <li>An AI startup/scale-up founder building machine learning solutions</li>
                                             <li>An industry professional looking to procure, develop or interact with AI systems</li>
@@ -265,7 +265,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                             <li>A data scientist performing analysis on big data or building statistical models</li>
                                             <li>A product, project or delivery manager involved in any stage of a ML system lifecycle</li>
                                         </ul>
-                                        <p>The "Ethical ML Network (BETA)" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Machine Learning Principles.</p>
+                                        <p>The "Ethical AI Network" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Machine Learning Principles.</p>
                                     </section>
                                 </div>
                             </div>

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 The AI-RFX is a procurement framework is a set of templates to empower industry practitioners to raise the bar for AI safety, quality and performance.
                                 <br>
                                 <br>
-                                The framework is open source, and converts the the <a href="https://ethical.institute/principles.html">Principles for Responsible Machine Learning</a> into a checklist.
+                                The framework is open source, and converts the <a href="https://ethical.institute/principles.html">Responsible AI Principles</a> into a checklist.
                             </h3>
                         </header>
 					</div>
@@ -218,8 +218,8 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 								<!-- Content -->
                                 <section id="content">
                                     <h3>Raising the bar for AI safety, quality and performance in industry</h3>
-                                    <p>The AI-RFX procurement framework has been put together by a group of domain experts. Its purpose is to ensure best practices in industry during the procurement, design, devleopment and integration of machine learning systems in industry.</p>
-                                    <p>The framework goes beyond the AI algorithms and provides a method to assess the maturity of the processes and technical infrastructure around the algorithms. The rramework consists of a request for proposal template as well as an assessment criteria template that is based on our Machine Learnign Maturity Model which can be downloaded at the <a href="rfx.html">AI-RFX Procurement Framework page</a>.</p>
+                                    <p>The AI-RFX procurement framework has been put together by a group of domain experts. Its purpose is to ensure best practices in industry during the procurement, design, development and integration of machine learning systems in industry.</p>
+                                    <p>The framework goes beyond the AI algorithms and provides a method to assess the maturity of the processes and technical infrastructure around the algorithms. The framework consists of a request for proposal template as well as an assessment criteria template that is based on our Machine Learning Maturity Model which can be downloaded at the <a href="rfx.html">AI-RFX Procurement Framework page</a>.</p>
 
                                     <br>
                                     <hr/>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>
@@ -19,9 +19,9 @@ description: The Institute for Ethical AI & Machine Learning is a Europe-based r
 					<div class="content" style="text-align: center">
 						<img class="logo-image" src="images/logos/eml-logo-white.png" alt="" style="max-width: 440px; width: 80%" />
 						<header style="font-weight: bold">
-							<h2>The Institute for Ethical AI & Machine Learning</h2>
+							<h2>The Institute for Ethical AI Alignment & Safety</h2>
                             <p  style="max-width: 850px">
-                                The Institute for Ethical AI & Machine Learning is a Europe-based research centre that develops frameworks that support the responsible development, deployment and operation of machine learning systems.
+                                The Institute for Ethical AI Alignment & Safety is a Europe-based research centre that develops frameworks that support the responsible development, deployment and operation of machine learning systems.
                                 <br>
                                 <br>
                                 We are formed by cross functional <a href="network.html">teams of volunteers</a> including leaders in technology, machine learning, industry, policy and academia (STEM, Humanities and Social Sciences).
@@ -243,7 +243,7 @@ description: The Institute for Ethical AI & Machine Learning is a Europe-based r
                                     <section id="sidebar">
                                         <hr>
                                         <section>
-                                            <h3>About The Institute for Ethical AI & Machine Learning</h3>
+                                            <h3>About The Institute for Ethical AI Alignment & Safety</h3>
                                             <p>We are a Europe-based think tank that brings together technology leaders, policymakers & academics to develop industry standards for Data Governance & Machine Learning. </p>
                                             <footer>
                                                 <ul class="actions">

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 								</section>
 								<section class="3u 6u$(medium) 12u$(xsmall)">
 									<span class="icon alt major fa-exclamation-triangle"></span>
-                                    <h3><a href="principles.html#commitment-8">8. Security risks</a></h3>
+                                    <h3><a href="principles.html#commitment-8">8. Security & data risk</a></h3>
                                     <p>I commit to develop and improve reasonable processes and infrastructure to ensure data and model security are being taken into consideration during the development of machine learning systems.</p>
 								</section>
                             </div>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 We have a commitment to advocate for the responsible development of AI
                             </h2>
                             <h3>
-                                We are a research centre that carries out highly-technical, practical and cross-functional research across <a href="#principles">the 8 Machine Learning Principles</a>.
+                                We are a research centre that carries out highly-technical, practical and cross-functional research across <a href="#principles">the 9 Responsible AI Principles</a>.
 
                                 <br>
                                 <br>
@@ -93,7 +93,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                         <br>
                         <br>
                         <br>
-                        <h2>Learn more about the <a href="#principles">8 principles below</a>, or join <a href="#contact">the Ethical AI Network</a>.</h2>
+                        <h2>Learn more about the <a href="#principles">9 principles below</a>, or join <a href="#contact">the Ethical AI Network</a>.</h2>
 
                     </div>
                 </section>
@@ -105,15 +105,15 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 					<div id="principles" class="content">
                        <header class="major" style="text-align: center">
                             <h2>
-                                The 8 machine learning principles
+                                The 9 Responsible AI Principles
                             </h2>
                             <h3>
-                                The Machine Learning Principles are a practical framework put together by domain experts.
+                                The Responsible AI Principles are a practical framework put together by domain experts.
                                 <br>Their objective is to provide guidance for technologists to develop machine learning systems responsibly.
                                 <br>
                                 <br>
                                 <br>
-                                Below are the summarised 8 principles. For full descriptions go to <a href="principles.html">the principles page</a>.
+                                Below are the summarised 9 principles. For full descriptions go to <a href="principles.html">the principles page</a>.
                             </h3>
                         </header>
 					</div>
@@ -163,6 +163,11 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 									<span class="icon alt major fa-exclamation-triangle"></span>
                                     <h3><a href="principles.html#commitment-8">8. Security & data risk</a></h3>
                                     <p>I commit to develop and improve reasonable processes and infrastructure to ensure data and model security are being taken into consideration during the development of machine learning systems.</p>
+								</section>
+								<section class="3u 6u(medium) 12u$(xsmall)">
+									<span class="icon alt major fa-compass"></span>
+                                    <h3><a href="principles.html#commitment-9">9. Alignment with intent</a></h3>
+                                    <p>I commit to evaluate whether systems pursue the objectives intended by their operators and stakeholders, and to test for goal misgeneralisation, misuse and deceptive behaviour where reasonable.</p>
 								</section>
                             </div>
                         </div>
@@ -256,7 +261,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 <div id="network" class="8u$ 12u$(medium) important(medium)">
                                     <section id="content">
                                         <h3 id="network">Apply to join the Ethical AI Network</h3>
-                                        <p>The Ethical AI Network is a global network of diverse engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 8 principles for responsible development of machine learning</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. If you'd like to join, you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
+                                        <p>The Ethical AI Network is a global network of diverse engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 9 Responsible AI Principles</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. If you'd like to join, you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
                                         <ul>
                                             <li>An AI startup/scale-up founder building machine learning solutions</li>
                                             <li>An industry professional looking to procure, develop or interact with AI systems</li>
@@ -265,7 +270,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                             <li>A data scientist performing analysis on big data or building statistical models</li>
                                             <li>A product, project or delivery manager involved in any stage of a ML system lifecycle</li>
                                         </ul>
-                                        <p>The "Ethical AI Network" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Machine Learning Principles.</p>
+                                        <p>The "Ethical AI Network" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Responsible AI Principles.</p>
                                     </section>
                                 </div>
                             </div>

--- a/mle.html
+++ b/mle.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 image-banner: https://ethical.institute/images/mle.jpg
 ---
 <html>

--- a/mlmm.html
+++ b/mlmm.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 image-banner: https://ethical.institute/images/flyer.jpg
 ---
 <html>

--- a/mlmm.html
+++ b/mlmm.html
@@ -39,7 +39,7 @@ Tender Competition Template”</a>.
 
 <p>The Machine Learning Maturity Model is an extension of <a href="https://ethical.institute/principles.html">The
 Principles for Responsible Machine Learning</a>, which aims to
-convert the high level Responsible ML Principles into a practical
+convert the high level Responsible AI Principles into a practical
 checklist-style assessment criteria. This “checklist” goes beyond
 the machine learning algorithms themselves, and provides an
 assessment criteria to evaluate the maturity of the infrastructure
@@ -71,7 +71,7 @@ Responsible Machine Learning</a>, and consists of the following:</p>
 			<p>Assessment Criteria</p>
 		</td>
 		<td  >
-			<p>Responsible ML Principle</p>
+			<p>Responsible AI Principle</p>
 		</td>
 	</tr>
 	<tr>
@@ -173,7 +173,7 @@ Responsible Machine Learning</a>, and consists of the following:</p>
 </tbody></table></div>
 <hr>
 <h3 class="western">0.2 - About Us</h3>
-<p>The Institute for Ethical AI &amp; Machine Learning is a Europe-based
+<p>The Institute for Ethical AI Alignment &amp; Safety is a Europe-based
 research centre that carries out world class research into
 responsible machine learning systems. We are formed by cross
 functional teams of applied STEM researchers, philosophers, industry
@@ -263,7 +263,7 @@ expected in machine learning systems will keep increasing, whilst
 being kept in check on a realistic level by both suppliers and
 companies.</p>
 <h4 class="western">0.6.2 - Contributing.md</h4>
-<p>The Institute for Ethical AI &amp; Machine Learning’s AI-RFX
+<p>The Institute for Ethical AI Alignment &amp; Safety’s AI-RFX
 committee is in charge of the contributing community for all of the
 templates under the AI-RFX Procurement Framework. &nbsp;Anyone who
 would like to contribute, add suggestions, or provide example and
@@ -771,7 +771,7 @@ Machine Learning Principle #2: Bias evaluation</a>.
 	awareness of domain-specific considerations</p>
 </li></ul>
 
-<p>The Institute for Ethical AI &amp; Machine Learning is working
+<p>The Institute for Ethical AI Alignment &amp; Safety is working
 with the IEEE p7003 working group to develop the <a href="https://standards.ieee.org/project/7003.html">p7003
 Algorithmic Bias Considerations standard</a> that will facilitate
 this assessment criteria once it is released as suppliers that obtain

--- a/mlmm.html
+++ b/mlmm.html
@@ -38,7 +38,7 @@ Tender Competition Template”</a>.
 </p>
 
 <p>The Machine Learning Maturity Model is an extension of <a href="https://ethical.institute/principles.html">The
-Principles for Responsible Machine Learning</a>, which aims to
+Responsible AI Principles</a>, which aims to
 convert the high level Responsible AI Principles into a practical
 checklist-style assessment criteria. This “checklist” goes beyond
 the machine learning algorithms themselves, and provides an
@@ -181,9 +181,9 @@ experts, data scientists and software engineers.</p>
 
 <p>Our vision is to mitigate risks of AI and unlock its full
 potential through frameworks that ensure ethical and conscientious
-development of intelligent systems across industrial sectors. We are
-building the Bell Labs of the 21st Century by delivering breakthrough
-contributions through applied AI research. You can find more
+development of intelligent systems across industrial sectors. We
+deliver breakthrough contributions through applied, open-source AI
+research. You can find more
 information about us at <a href="https://ethical.institute/">https://ethical.institute</a>.</p>
 <hr>
 <h3 class="western">0.3 - Motivation

--- a/mlmm.html
+++ b/mlmm.html
@@ -167,7 +167,7 @@ Responsible Machine Learning</a>, and consists of the following:</p>
 		</td>
 		<td >
 			<p><a href="https://ethical.institute/principles.html#commitment-8">Principle
-			#8: Security risks</a></p>
+			#8: Security & data risk</a></p>
 		</td>
 	</tr>
 </tbody></table></div>
@@ -1830,7 +1830,7 @@ Machine Learning Principle #5 - Displacement strategy</a>.
 risk processes</h3>
 <p>This Machine Learning Maturity Model assessment criteria is
 directly aligned with the <a href="https://ethical.institute/principles.html#commitment-8">Responsible
-Machine Learning Principle #8 - Data risk awareness</a>. 
+Responsible AI Principle #8 - Security & data risk</a>. 
 </p>
 <h4 class="western">Explanation</h4>
 <ul>

--- a/network.html
+++ b/network.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 no-bootstrap: "true"
 ---
 <html>

--- a/network.html
+++ b/network.html
@@ -18,7 +18,7 @@ no-bootstrap: "true"
 					<div class="container">
 						<header class="major">
 							<h2>Ethical AI Network</h2>
-                            <p>The Ethical AI Network is a global network of volunteers consisting of engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 8 principles for responsible development of machine learning</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. If you'd like to join, you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
+                            <p>The Ethical AI Network is a global network of volunteers consisting of engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 9 Responsible AI Principles</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. If you'd like to join, you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
                                         <ul>
                                             <li>An AI startup/scale-up founder building machine learning solutions</li>
                                             <li>An industry professional looking to procure, develop or interact with AI systems</li>
@@ -27,8 +27,8 @@ no-bootstrap: "true"
                                             <li>A data scientist performing analysis on big data or building statistical models</li>
                                             <li>A product, project or delivery manager involved in any stage of a ML system lifecycle</li>
                                         </ul>
-                                        <p>The "Ethical AI Network" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Machine Learning Principles.</p>
-                                        <p>The members of the Ethical AI Network contribute to the open source workstreams at the institute, which include our <a href="principles.html">8 Principles for Responsible ML</a>, the <a href="rfx.html">AI RFX Framework</a>, and our <a href="https://github.com/EthicalML/"></a>open source libraries and frameworks</a></p>
+                                        <p>The "Ethical AI Network" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Responsible AI Principles.</p>
+                                        <p>The members of the Ethical AI Network contribute to the open source workstreams at the institute, which include our <a href="principles.html">9 Responsible AI Principles</a>, the <a href="rfx.html">AI RFX Framework</a>, and our <a href="https://github.com/EthicalML/"></a>open source libraries and frameworks</a></p>
                             <h2>Current members include:</h2>
                             <table class="table table-bordered table-hover table-condensed">
 <thead><tr><th title="Field #1">FIRSTNAME</th>

--- a/network.html
+++ b/network.html
@@ -18,7 +18,7 @@ no-bootstrap: "true"
 					<div class="container">
 						<header class="major">
 							<h2>Ethical AI Network</h2>
-                            <p>The Ethical ML Network (BETA) is a global network of volunteers consisting of engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 8 principles for responsible development of machine learning</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. The network is currently on BETA, so if you want to join you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
+                            <p>The Ethical AI Network is a global network of volunteers consisting of engineers, scientists, managers, leaders and thinkers that align on <a href="#principles">the 8 principles for responsible development of machine learning</a>, and support the <a href="#phases">4 phases towards responsible development of AI</a>. If you'd like to join, you can submit a request in the <a href="#contact">form below</a>. This network is relevant if you are:</p>
                                         <ul>
                                             <li>An AI startup/scale-up founder building machine learning solutions</li>
                                             <li>An industry professional looking to procure, develop or interact with AI systems</li>
@@ -27,7 +27,7 @@ no-bootstrap: "true"
                                             <li>A data scientist performing analysis on big data or building statistical models</li>
                                             <li>A product, project or delivery manager involved in any stage of a ML system lifecycle</li>
                                         </ul>
-                                        <p>The "Ethical ML Network (BETA)" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Machine Learning Principles.</p>
+                                        <p>The "Ethical AI Network" is a play on words which reinforces our core ethos. We believe that the only machine learning network that can be induced with ethics in practical industrial usecases is one made out of responsible and aligned humans who advocate for best practices during the design and development of machine learning systems. This is reinforced in each one of the Machine Learning Principles.</p>
                                         <p>The members of the Ethical AI Network contribute to the open source workstreams at the institute, which include our <a href="principles.html">8 Principles for Responsible ML</a>, the <a href="rfx.html">AI RFX Framework</a>, and our <a href="https://github.com/EthicalML/"></a>open source libraries and frameworks</a></p>
                             <h2>Current members include:</h2>
                             <table class="table table-bordered table-hover table-condensed">

--- a/principles.html
+++ b/principles.html
@@ -17,12 +17,12 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 
 				<section id="banner" style="font-size: 11pt">
 					<div class="content" style="text-align: center">
-                        <h2 style="font-size: 4em; color: #01C3A7; font-weight: bold; text-align: center; line-height: 1.3em; margin-bottom: 20px">The Responsible Machine Learning Principles</h2>
+                        <h2 style="font-size: 4em; color: #01C3A7; font-weight: bold; text-align: center; line-height: 1.3em; margin-bottom: 20px">The Responsible AI Principles</h2>
 						<img class="logo-image" src="images/logos/eml-logo-white.png" alt="" style="max-width: 440px; width: 80%; margin-top: 30px" />
 						<header>
                             <h2 style="font-weight: bold; margin-top:0px">A practical framework to develop AI responsibly</h2>
                             <p style="font-weight: bold; max-width: 850px">
-                                The 8 principles of responsible ML development provide a practical framework to support technologists when designing, developing or maintaining systems that learn from data.
+                                The 9 Responsible AI Principles provide a practical framework to support technologists when designing, developing or maintaining systems that learn from data.
                                 <br>
                                 <br>
                                 If these principles resonate with you, you invite you to join the <a href="index.html#contact">Ethical AI Network</a>, and be part of a global network of leaders driving forward positive change in this area.
@@ -39,10 +39,10 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 					<div class="content">
                         <header class="major">
                             <h2>
-                                The Responsible Machine Learning Principles
+                                The Responsible AI Principles
                             </h2>
                             <h3>
-                                The Responsible Machine Learning Principles are a practical framework put together by domain experts.
+                                The Responsible AI Principles are a practical framework put together by domain experts.
                                 <br>Their purpose is to provide guidance for technologists to develop machine learning systems responsibly.
                                 <br>
                                 <br>
@@ -95,6 +95,11 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 									<span class="icon alt major fa-exclamation-triangle"></span>
                                     <h3><a href="#commitment-8">8. Security & data risk</a></h3>
                                     <p>I commit to develop and improve reasonable processes and infrastructure to ensure data and model security are being taken into consideration during the development of machine learning systems.</p>
+								</section>
+								<section class="3u 6u(medium) 12u$(xsmall)">
+									<span class="icon alt major fa-compass"></span>
+                                    <h3><a href="#commitment-9">9. Alignment with intent</a></h3>
+                                    <p>I commit to evaluate whether systems pursue the objectives intended by their operators and stakeholders, and to test for goal misgeneralisation, misuse and deceptive behaviour where reasonable.</p>
 								</section>
                             </div>
                         </div>
@@ -488,8 +493,24 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                     </div>
                 </section>
                 
- 
-                <section id="one" class="spotlight style1 bottom">
+				<section id="nine" class="spotlight style2 right stylelong">
+					<span class="image fit main"><img src="images/robothand.png" alt="" /></span>
+					<div class="content">
+						<header>
+							<h2 id="commitment-9">9. Alignment with intent</h2>
+                            <p>I commit to evaluate whether systems pursue the objectives intended by their operators and stakeholders, and to test for goal misgeneralisation, misuse and deceptive behaviour where reasonable.</p>
+						</header>
+						<p>As AI systems become more capable and autonomous — including large language models and agentic systems — measuring accuracy is no longer enough. We must ask whether a system is actually pursuing the objective its operators and stakeholders intended.</p>
+                        <p>Misalignment can surface as goal misgeneralisation (the system optimises a proxy that diverges from intent outside training), as misuse (capable systems repurposed for harm), or as deceptive or manipulated behaviour under adversarial pressure.</p>
+                        <p>Technologists should commit to evaluate alignment explicitly — through red-teaming, behavioural evaluations, and meaningful human oversight of high-stakes decisions — and to document residual risks where full assurance is not yet possible.</p>
+						<ul class="actions">
+							<li><a href="index.html#contact" class="button">Join the network</a></li>
+						</ul>
+					</div>
+					<a href="#join" class="goto-next scrolly">Next</a>
+				</section>
+
+                <section id="join" class="spotlight style1 bottom">
                     <span class="image fit main"><img src="images/dots-vision.jpg" alt="" /></span>
 					<div class="content">
 						<div class="container">

--- a/principles.html
+++ b/principles.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>

--- a/principles.html
+++ b/principles.html
@@ -93,7 +93,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 								</section>
 								<section class="3u 6u$(medium) 12u$(xsmall)">
 									<span class="icon alt major fa-exclamation-triangle"></span>
-                                    <h3><a href="#commitment-8">8. Data risk awareness</a></h3>
+                                    <h3><a href="#commitment-8">8. Security & data risk</a></h3>
                                     <p>I commit to develop and improve reasonable processes and infrastructure to ensure data and model security are being taken into consideration during the development of machine learning systems.</p>
 								</section>
                             </div>
@@ -448,7 +448,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 					<span class="image fit main bottom"><img src="images/pairprogramming.jpg" alt="" /></span>
 					<div class="content">
                         <header>
-							<h2 id="commitment-8">8. Data risk awareness</h2>
+							<h2 id="commitment-8">8. Security & data risk</h2>
                             <p>I commit to develop and improve reasonable processes and infrastructure to ensure data and model security are being taken into consideration during the development of machine learning systems.</p>
 						</header>
 						<p>Autonomous decision-making systems open the doors to new potential security breaches.</p>
@@ -464,7 +464,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                 <section id="four" class="wrapper style1 special fade-up">
 					<div class="container">
 						<header class="major">
-							<h2>8. Security risks</h2>
+							<h2>8. Security & data risk</h2>
                             <p>What are some examples where I should focus to become aware of potential risks in my data and models?</p>
 						</header>
 						<div class="box alt">

--- a/principles.html
+++ b/principles.html
@@ -25,7 +25,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 The 8 principles of responsible ML development provide a practical framework to support technologists when designing, developing or maintaining systems that learn from data.
                                 <br>
                                 <br>
-                                If these principles resonate with you, you invite you to join the <a href="index.html#contact">Ethical ML Network (BETA)</a>, and be part of a global network of leaders driving forward positive change in this area.
+                                If these principles resonate with you, you invite you to join the <a href="index.html#contact">Ethical AI Network</a>, and be part of a global network of leaders driving forward positive change in this area.
                             </p>
 						</header>
                     <br>
@@ -494,7 +494,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 					<div class="content">
 						<div class="container">
                             <header class="major">
-                                <h2>If these principles resonate with you, we invite you to join the <a href="index.html#contact">Ethical ML Network (BETA)</a></h2>
+                                <h2>If these principles resonate with you, we invite you to join the <a href="index.html#contact">Ethical AI Network</a></h2>
                             </header>
                         </div>
 					</div>

--- a/principles.html
+++ b/principles.html
@@ -145,8 +145,8 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 							<div class="row uniform">
 								<section class="4u 6u(medium) 12u$(xsmall)">
 									<span class="icon alt major fa-flask"></span>
-									<h3>Automatic prision sentence scrutiny</h3>
-                                    <p><a href="https://www.wired.com/2017/04/courts-using-ai-sentence-criminals-must-stop-now/">A fully end-to-end machine learning system that predicts prison sentences automatically</a> is a classic example of a system that should be deployed carefuly, ideally with a human-in-the-loop review. Especially given that in this example, the inner workings of the model cannot be explained which is addressed in <a href="#commitment-5">Commitment #5</a>.</p>
+									<h3>Automatic prison sentence scrutiny</h3>
+                                    <p><a href="https://www.wired.com/2017/04/courts-using-ai-sentence-criminals-must-stop-now/">A fully end-to-end machine learning system that predicts prison sentences automatically</a> is a classic example of a system that should be deployed carefully, ideally with a human-in-the-loop review. Especially given that in this example, the inner workings of the model cannot be explained which is addressed in <a href="#commitment-5">Commitment #5</a>.</p>
 								</section>
 								<section class="4u 6u$(medium) 12u$(xsmall)">
 									<span class="icon alt major fa-comment"></span>

--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>
@@ -25,7 +25,7 @@ description: The Institute for Ethical AI & Machine Learning is a Europe-based r
 
 						<!-- Text -->
 							<section>
-                                <p>The Institute for Ethical AI & Machine Learning (“Company”) is committed to protecting the privacy of your information. This Privacy Statement describes the Company’s information practices.</p>
+                                <p>The Institute for Ethical AI Alignment & Safety (“Company”) is committed to protecting the privacy of your information. This Privacy Statement describes the Company’s information practices.</p>
 								<h2>1. Websites Covered</h2>
                                 <p>This Privacy Statement covers the information practices of Web sites that link to this Privacy Statement: <a href="https://ethical.institute/privacypolicy.html">https://ethical.institute/privacypolicy.html</a>.</p>
                                 <p>The Company’s Web sites may contain links to other Web sites. The Company is not responsible for the information practices or the content of such other Web sites. The Company encourages you to review the privacy statements of other Web sites to understand their information practices.</p>

--- a/rfp.html
+++ b/rfp.html
@@ -370,7 +370,7 @@ below.</p>
 						<p>7 - Trust by privacy</p>
 					</td>
 					<td  >
-						<p>8 - Security risks</p>
+						<p>8 - Security & data risk</p>
 					</td>
 					<td  >
 						

--- a/rfp.html
+++ b/rfp.html
@@ -73,9 +73,9 @@ experts, data scientists and software engineers.</p>
 
 <p>Our vision is to mitigate risks of AI and unlock its full
 potential through frameworks that ensure ethical and conscientious
-development of intelligent systems across industrial sectors. We are
-building the Bell Labs of the 21st Century by delivering breakthrough
-contributions through applied AI research. You can find more
+development of intelligent systems across industrial sectors. We
+deliver breakthrough contributions through applied, open-source AI
+research. You can find more
 information about us at <a href="https://ethical.institute/">https://ethical.institute</a>.</p>
 <hr>
 <h3 class="western" >0.3 -
@@ -321,8 +321,8 @@ aware.</p>
 
 <hr>
 <h3 class="western">1.4 - Responsibility Commitment</h3>
-<p>This section requests suppliers to ensure they follow the 8
-Principles for Responsible Machine Learning development. The 8
+<p>This section requests suppliers to ensure they follow the 9
+Responsible AI Principles. The 9
 commitments are implemented in this framework through the Machine
 Learning Maturity Model, and they are implicit on each section.</p>
 
@@ -405,7 +405,7 @@ specific requirements.</p>
 <p >Company website:
 				<a href="https://ethical.institute/">https://ethical.institute</a></p>
 				</li><li>
-<p >The 8 Machine Learning
+<p >The 9 Responsible AI
 				Principles: <a href="https://ethical.institute/principles.html">https://ethical.institute/principles.html</a></p>
 				</li><li>
 <p >...</p>

--- a/rfp.html
+++ b/rfp.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>

--- a/rfp.html
+++ b/rfp.html
@@ -65,7 +65,7 @@ quality and performance.
 </p>
 <hr>
 <h3 class="western">0.2 - About Us</h3>
-<p>The Institute for Ethical AI &amp; Machine Learning is a Europe-based
+<p>The Institute for Ethical AI Alignment &amp; Safety is a Europe-based
 research centre that carries out world class research into
 responsible machine learning systems. We are formed by cross
 functional teams of applied STEM researchers, philosophers, industry
@@ -194,7 +194,7 @@ expected in machine learning systems will keep increasing, whilst
 being kept in check on a realistic level by both suppliers and
 companies.</p>
 <h4 class="western">0.6.2 - Contributing.md</h4>
-<p>The Institute for Ethical AI &amp; Machine Learning’s AI-RFX
+<p>The Institute for Ethical AI Alignment &amp; Safety’s AI-RFX
 committee is in charge of the contributing community for all of the
 templates under the AI-RFX Procurement Framework. &nbsp;Anyone who
 would like to contribute, add suggestions, or provide example and
@@ -336,8 +336,8 @@ below.</p>
 			<p>Example Responsibility Commitment</p>
 			
 			<p>This request for proposal requires all suppliers to follow the
-			8 principles for responsible machine learning defined by The
-			Institute for Ethical AI &amp; Machine Learning. The 8 principles
+			9 Responsible AI Principles defined by The
+			Institute for Ethical AI Alignment &amp; Safety. The 9 principles
 			state best practices in each area, and as it is stated, they don’t
 			always have to be implemented in every project, but when this is
 			the case it should be an explicit decision not to.</p>
@@ -373,13 +373,13 @@ below.</p>
 						<p>8 - Security & data risk</p>
 					</td>
 					<td  >
-						
+						<p>9 - Alignment with intent</p>
 					</td>
 				</tr>
 			</tbody></table>
 			
-			<p>You can find the Machine Learning Principles by The Institute
-			for Ethical AI &amp; Machine Learning at
+			<p>You can find the Responsible AI Principles by The Institute
+			for Ethical AI Alignment &amp; Safety at
 			<a href="https://ethical.institute/principles.html">https://ethical.institute/principles.html</a>
 						</p>
 		</td>

--- a/rfx.html
+++ b/rfx.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 image-banner: https://ethical.institute/images/flyer.jpg
 ---
 <html>

--- a/rfx.html
+++ b/rfx.html
@@ -46,7 +46,7 @@ image-banner: https://ethical.institute/images/flyer.jpg
                                 The AI-RFX is a procurement framework is a set of templates to empower industry practitioners to raise the bar for AI safety, quality and performance.
                                 <br>
                                 <br>
-                                The framework is open source, and converts the the <a href="https://ethical.institute/principles.html">Principles for Responsible Machine Learning</a> into a checklist.
+                                The framework is open source, and converts the <a href="https://ethical.institute/principles.html">Responsible AI Principles</a> into a checklist.
                             </h3>
                         </header>
 					</div>
@@ -66,7 +66,7 @@ image-banner: https://ethical.institute/images/flyer.jpg
                                             <p>You can also apply to become a member of our <a href="#contact">Ethical AI Network</a> and get access to more resources, including reports, case studies, as well as invitations to exclusive events and round tables.</p>
 											<a href="#" class="image fit"><img src="images/rfx-cover.png" alt="" /></a>
 											<h3>Free as in freedom</h3>
-                                            <p>The tempalte has been released on under an <a href="https://github.com/EthicalML/ai-rfx-procurement-framework">MIT open source license</a> to enable suppliers and industry practitioners to submit changes, case studies or examples. The AI-RFX framework is maintained by a global community of technologists and domain experts. If you are interested to contribute in this or similar projects apply to join the <a href="#contact">Ethical AI Network</a>, or get in touch through <a href="#contact">the contact form below</a></p>
+                                            <p>The template has been released on under an <a href="https://github.com/EthicalML/ai-rfx-procurement-framework">MIT open source license</a> to enable suppliers and industry practitioners to submit changes, case studies or examples. The AI-RFX framework is maintained by a global community of technologists and domain experts. If you are interested to contribute in this or similar projects apply to join the <a href="#contact">Ethical AI Network</a>, or get in touch through <a href="#contact">the contact form below</a></p>
 										</section>
 								</section>
 
@@ -76,7 +76,7 @@ image-banner: https://ethical.institute/images/flyer.jpg
 								<!-- Content -->
 									<section id="content">
 										<h3>Raising the bar for AI safety, quality and performance in industry</h3>
-										<p>The AI-RFX procurement framework has been put together by a group of domain experts. Its purpose is to ensure best practices in industry during the procurement, design, devleopment and deployment of machine learning systems in industry.</p>
+										<p>The AI-RFX procurement framework has been put together by a group of domain experts. Its purpose is to ensure best practices in industry during the procurement, design, development and deployment of machine learning systems in industry.</p>
                                         <p>This procurement framework goes beyond the machine learning algorithms. It provides a method to assess the maturity level of the technical infrastructure and processes around the algorithms themselves, by using our Machine Learning Maturity Model.</p>
 
                                         <hr/>

--- a/rfx.html
+++ b/rfx.html
@@ -133,7 +133,7 @@ image-banner: https://ethical.institute/images/flyer.jpg
 											<tr>
 												<td>#8</td>
 												<td>Security risk mitigations</td>
-												<td><a href="principles.html#commitment-8">Principle #8: Security risks</a></td>
+												<td><a href="principles.html#commitment-8">Principle #8: Security & data risk</a></td>
 											</tr>
 
 										</tbody>

--- a/rfx.html
+++ b/rfx.html
@@ -63,7 +63,7 @@ image-banner: https://ethical.institute/images/flyer.jpg
 										<section>
                                             <h3>Download a copy</h3>
                                             <p>You can request a free copy of the AI-RFX Procurement Framework through <a href="#contact">the contact form below</a>, which will include the AI Request for Proposal template, and the AI Machine Learning Maturity Model. 
-                                            <p>You can also apply to become a member of our <a href="#contact">Ethical AI Network (BETA)</a> and get access to more resources, including reports, case studies, as well as invitations to exclusive events and round tables.</p>
+                                            <p>You can also apply to become a member of our <a href="#contact">Ethical AI Network</a> and get access to more resources, including reports, case studies, as well as invitations to exclusive events and round tables.</p>
 											<a href="#" class="image fit"><img src="images/rfx-cover.png" alt="" /></a>
 											<h3>Free as in freedom</h3>
                                             <p>The tempalte has been released on under an <a href="https://github.com/EthicalML/ai-rfx-procurement-framework">MIT open source license</a> to enable suppliers and industry practitioners to submit changes, case studies or examples. The AI-RFX framework is maintained by a global community of technologists and domain experts. If you are interested to contribute in this or similar projects apply to join the <a href="#contact">Ethical AI Network</a>, or get in touch through <a href="#contact">the contact form below</a></p>

--- a/rfx.html
+++ b/rfx.html
@@ -83,7 +83,7 @@ image-banner: https://ethical.institute/images/flyer.jpg
 										<h3 id="model">The Machine Learning Maturity Model</h3>
 										<p>The Machine Learning Maturity Model is a set of criteria which ensures that the core technical infrastructure and the right processes are in place. It provides the ability for key industry practitioners to set a bar for quality, safety and performance when procuring machine learning solutions. You can request to download a copy of the AI-RFX Framework through <a href="#contact">the contact form below</a>, which contains this document as well.</p>
                                         <p>
-                                        The model was designed using the <a href="principles.html">Responsible Machine Learning Principles</a>, and consists of the following 8 assessment criteria:
+                                        The model was designed using the <a href="principles.html">Responsible AI Principles</a>, and consists of the following 8 assessment criteria:
                                         </p>
                                     <div class="table-wrapper">
 									<table class="alt">
@@ -91,7 +91,7 @@ image-banner: https://ethical.institute/images/flyer.jpg
 											<tr>
 												<th>Number</th>
 												<th>Assessment Criteria</th>
-												<th>Responsible ML Principle</th>
+												<th>Responsible AI Principle</th>
 											</tr>
 										</thead>
                                             <tbody>

--- a/security.html
+++ b/security.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>

--- a/security.html
+++ b/security.html
@@ -21,7 +21,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 						<header>
                             <h2 style="font-size: 4em; color: #01C3A7; font-weight: bold; text-align: center; line-height: 1.3em; margin-bottom: 20px">The MLSecOps Top 10</h2>
                             <p style="font-weight: bold; max-width: 850px; font-size: 1.25em">
-                                The <a href="#four">MLSecOps Top 10</a> is an initiative that aims to further the field of machine learning security by identifying the top 10 most common vulnerabiliites in the machine learning lifecycle. This project aims to provide an evaluation of security vulnerabilities analogous to the <a href="https://owasp.org/www-project-top-ten/">"OWASP Top 10 Report"</a> but with a focus on machine learning security.
+                                The <a href="#four">MLSecOps Top 10</a> is an initiative that aims to further the field of machine learning security by identifying the top 10 most common vulnerabilities in the machine learning lifecycle. This project aims to provide an evaluation of security vulnerabilities analogous to the <a href="https://owasp.org/www-project-top-ten/">"OWASP Top 10 Report"</a> but with a focus on machine learning security. The MLSecOps Top 10 extends naturally to LLM and agentic systems, complementing the OWASP LLM Top 10.
                             </p>
                                 <br>
                             <p style="font-weight: bold; max-width: 850px; font-size: 1.25em">
@@ -45,7 +45,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 Combining cutting edge research tools with best practices & processes to ensure machine learning systems are secure and undesired vulnerabilities are mitigated. Check out the <a href="#mlsecops-video">resources and video below</a> which cover MLSecOps from a conceptual and practical perspective.
                                 <br>
                                 <br>
-                                The MLSecOps Top 10 is <a href="https://github.com/EthicalML/fml-security">open source</a>, and converts the <a href="https://ethical.institute/principles.html">Principles for Responsible Machine Learning</a> into a practical tool + process approach.
+                                The MLSecOps Top 10 is <a href="https://github.com/EthicalML/fml-security">open source</a>, and converts the <a href="https://ethical.institute/principles.html">Responsible AI Principles</a> into a practical tool + process approach.
                             </h3>
                         </header>
 					</div>

--- a/state-of-ml-2024.html
+++ b/state-of-ml-2024.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 image-banner: https://ethical.institute/images/prod-ml-survey-banner.jpg
 ---
 <html data-bs-theme="dark">

--- a/state-of-ml-2025.html
+++ b/state-of-ml-2025.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 image-banner: https://ethical.institute/images/prod-ml-survey-banner.jpg
 ---
 <html data-bs-theme="dark">

--- a/xai.html
+++ b/xai.html
@@ -1,6 +1,6 @@
 ---
-title: The Institute for Ethical AI & Machine Learning
-description: The Institute for Ethical AI & Machine Learning is a Europe-based research centre that brings togethers technologists, academics and policy-makers to develop industry frameworks that support the responsible development, design and operation of machine learning systems.
+title: The Institute for Ethical AI Alignment & Safety
+description: The Institute for Ethical AI Alignment & Safety is a research centre developing practical, open-source frameworks that help technologists, industry and policymakers build, evaluate and govern AI systems that are safe, aligned and accountable.
 ---
 <html>
 	<head>

--- a/xai.html
+++ b/xai.html
@@ -20,7 +20,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                         <h2 style="font-size: 4em; color: #01C3A7; font-weight: bold; text-align: center; line-height: 1.3em; margin-bottom: 20px">XAI - eXplainableAI Framework</h2>
 						<img class="logo-image" src="images/logos/eml-logo-white.png" alt="" style="max-width: 440px; width: 80%; margin-top: 30px" />
 						<header>
-                            <h2 style="font-weight: bold; margin-top:0px">An eXplainability framework for Machine Learning</h2>
+                            <h2 style="font-weight: bold; margin-top:0px">An interpretability and transparency framework for safer AI</h2>
                             <p style="font-weight: bold; max-width: 850px">
                             The <a href="https://github.com/EthicalML/XAI">XAI Framework</a> allows you to introduce explainability and perform bias evaluation in AI systems by going beyond algorithms using a tool+process approach.
                                 <br>
@@ -45,7 +45,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
                                 Combining cutting edge research tools with practical industry processes to ensure machine learning systems are explainable and undesired biases are mitigated.
                                 <br>
                                 <br>
-                                The XAI Framework is <a href="https://github.com/EthicalML/XAI">open source</a>, and converts the <a href="https://ethical.institute/principles.html">Principles for Responsible Machine Learning</a> into a practical tool + process approach.
+                                The XAI Framework is <a href="https://github.com/EthicalML/XAI">open source</a>, and converts the <a href="https://ethical.institute/principles.html">Responsible AI Principles</a> into a practical tool + process approach.
                             </h3>
                         </header>
 					</div>
@@ -74,7 +74,7 @@ description: The Institute for Ethical AI Alignment & Safety is a research centr
 								<!-- Content -->
 									<section id="content">
 										<h3>What do we mean by eXplainable AI?</h3>
-										<p>We see the challenge of explainability as more than just an algorithmic challenge. The XAI Framework is designed to empowers you to introduce explainability and perform bias evaluation through three steps: 1) data analysis, 2) model evaluation, and 3) production monitoring. This is visualised in the diagram below.</p>
+										<p>We see the challenge of explainability as more than just an algorithmic challenge. The XAI Framework is designed to empower you to introduce explainability and perform bias evaluation through three steps: 1) data analysis, 2) model evaluation, and 3) production monitoring. This is visualised in the diagram below.</p>
                                         <img src="images/bias.png" style="width: 100%">
 
                                         <br><br>


### PR DESCRIPTION
## Summary

Content/text rebrand of **The Institute for Ethical AI & Machine Learning** → **The Institute for Ethical AI Alignment & Safety**, narrowing the org's stated scope toward AI safety and alignment. This PR is text/content only — no structural or layout changes to the site.

## Changes (byte-sized commits)

| Commit | Change |
|--------|--------|
| `23d851d` | Rebrand org name across pages, meta description, and footer; fix `togethers` typo |
| `49f5e4c` | Unify the network as **Ethical AI Network**; drop every **(BETA)** marker |
| `190cc53` | Standardise principle #8 as **Security & data risk** |
| `5a21ed6` | Add 9th principle **Alignment with intent**; bump all "8 principles" counts to 9 |
| `cae73d5` | Modernise homepage hero toward safety/alignment/frontier/agents |
| `bb9139d` | Reframe initiatives toward safety; fix remaining typos; retire the dated "Bell Labs of the 21st Century" claim |

## Verification

Verified in headless Chromium (Playwright) against the built Jekyll site — 18/18 assertions passed:
- **index**: new org name present, legacy name gone, no (BETA), "9 Responsible AI Principles" phrase, #9 in principles grid, no `togethers` typo
- **principles**: 9 numbered summary headings, "9. Alignment with intent" heading, no legacy "Data risk awareness" label, `#commitment-9` anchor resolves to the correct heading
- **security / network**: HTTP 200, new org name, no (BETA)

Full-page screenshots confirmed intact layout on both the homepage and principles page.

## Explicitly preserved

- `mle/*` newsletter archive and `_site/` build output untouched
- Network members table (incl. the Nokia Bell Labs cell) unchanged
- Both NeurIPS keynote nav items preserved

## Deferred

Website/structure improvements were intentionally out of scope for this pass.
