### PR TITLE
Restore section eyebrow accent and colour prose links

### DIFF
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -637,6 +637,16 @@ dd { margin: 6px 0 0; }
   scroll-margin-top: 96px;
 }
 .prose-section-eyebrow { margin-bottom: 16px; }
+/* The eyebrow is a `.prose-section > p`, so the section's own paragraph colour
+   was overriding the shared `.eyebrow` accent. Restore it, and give
+   markdown-authored links the same accent that components get from
+   `.text-link`: prose links carry no class of their own, so without this they
+   inherit the body colour and cannot be told apart from the text. */
+.prose-section > .prose-section-eyebrow { color: var(--accent); }
+.prose-section > p a,
+.prose-section > ul a,
+.prose-content p a,
+.prose-content ul a { color: var(--accent); }
 .prose-section-title {
   font-size: var(--display-44);
   line-height: 1.08;


### PR DESCRIPTION
Two sitewide styling corrections found while reviewing the SEO content PR.

**Section eyebrows were grey, not accent.** The numbered eyebrow emitted by `rehype-sectionize` carries the shared `.eyebrow` class, but it is also a `.prose-section > p`, and that rule's `--text-2` colour overrode the accent. Every numbered section on the site was affected, not just the pages under review.

**Markdown links in prose had no link styling.** Components apply `.text-link` for accent links, but a link authored in MDX prose carries no class, so it inherited the paragraph colour with no underline and could not be told apart from body text. Internal links nobody can see do not get clicked, which matters for navigation and for internal link signal.

Verified with computed styles before and after on `/privacy/`, `/frameworks/security/` and `/principles/08/`: both now compute to `rgb(94, 230, 160)`. Lint, format, ratchet and build pass; DOM gates pass on those three routes at 1440x1000 and 420x900.