### PR TITLE
Add Bing Webmaster Tools verification file

### DIFF
--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>6D306D011FCCC7B495D1A536D1BE3F33</user>
+</users>


### PR DESCRIPTION
Serves `/BingSiteAuth.xml` from the site root so the Bing Webmaster Tools property can be verified. Verification unlocks the AI Performance report, the only free first-party data on how often Copilot and Bing AI experiences cite the site, which is the baseline for measuring the SEO and GEO work.