### PR TITLE
Trim newsletter issue meta descriptions

### DIFF
--- a/src/pages/newsletter/[issue].astro
+++ b/src/pages/newsletter/[issue].astro
@@ -30,10 +30,20 @@ const barDate = entry.data.date
 const position = numbers.indexOf(issue);
 const previous = position > 0 ? numbers[position - 1] : undefined;
 const next = position < numbers.length - 1 ? numbers[position + 1] : undefined;
+// Issue summaries are the description source and many run past the length
+// search results render, so they are trimmed on a word boundary rather than
+// cut mid-word by the engine.
+const truncateDescription = (value: string, maxLength = 160) => {
+  if (value.length <= maxLength) return value;
+  const candidate = value.slice(0, maxLength - 1).trimEnd();
+  return `${candidate.slice(0, candidate.lastIndexOf(' ')).replace(/[,:;]+$/, '')}…`;
+};
+
 const frontmatter = {
   title: `The ML Engineer — Issue #${issue}`,
-  description:
+  description: truncateDescription(
     entry.data.summary ?? 'The Machine Learning Engineer newsletter: curated articles, tutorials and insights from experienced machine learning professionals.',
+  ),
   article: true,
   articleHeadline: `The Machine Learning Engineer Issue #${issue}`,
   datePublished: entry.data.date?.toISOString().slice(0, 10),


### PR DESCRIPTION
Issue summaries are the meta description source and 199 of them exceeded the length search results render, so they were being cut mid-word. The issue template now trims anything over 160 characters at the last word boundary with an ellipsis. Verified across all 398 built issue pages: none exceeds 160 characters, longest is 159.

Scope note: this branch originally added topic hubs and year archives. Those are dropped. The archive index already server-renders all 398 issues, so crawl discovery was never the gap the audit implied, and hub pages would have duplicated the existing client-side tag filter. The valuable half of that audit finding, issue bodies linking to the Institute's own project pages instead of GitHub, shipped in #20.