### PR TITLE
Retire the prototype geometry stylesheet and add a section gap token

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,10 +18,6 @@ Owner has ideas for the newsletter beyond the carried-over archive (396 issues l
 
 Six homepage scroll-effect variants sit in the open PR #12, paused for owner decision: pick a variant to land or close the PR.
 
-## CSS spacing cleanup
-
-Retire `src/styles/layout.css` (prototype-fidelity pixel pins from round 4; the principles and open-source pins are already removed after one caused 43px of dead section space — verify the remaining join/footnote pins still earn their place, then delete the file). Introduce a single `--section-gap` rhythm token for the homepage inter-section distance instead of per-section one-offs.
-
 ## tokens.css breakup (post-cutover, pixel-perfect)
 
 Roughly 3/4 of tokens.css (~2,200 lines) is per-component styling; relocate it into the ~15-20 owning components, delete dead rules as they surface (likely 10-20%), and consolidate the five ad-hoc breakpoints (950/900/800/600/520) into 2-3 named ones. Zero visual change by construction: every batch gates on masked full-page screenshot parity for all 33 pages at 2-3 widths (definition of done #7). Run as a low-supervision worker campaign in 3-4 scoped rounds (survey+carousel → principles+hero → menus+cards+misc → breakpoints & sweep), ~30-45 min each; owner eye pass only where parity diffs flag. Deliberately deferred until after the redesign cutover so parity runs against a stable target. Standing guardrail effective now: no NEW component rules go into tokens.css — style in the owning component.
@@ -47,4 +43,3 @@ The achievements card and StatBand print "30+" per owner instruction; the record
 ## LLM-based survey
 
 I want to follow on from the State of Production ML 2025, but now for 2026. Instead of asking respondents, I want to do a slight twist on this: collect, through research, the ML stack from various companies from their public blog posts, etc. We would be able to build a report based on all of that. Right now, this could be a more meaningful approach as opposed to what could be a biassed survey response.
-

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,6 @@
 ---
 import '../styles/tokens.css';
 import '../styles/prose.css';
-import '../styles/layout.css';
 import { ClientRouter } from 'astro:transitions';
 import SiteHeader from '../components/SiteHeader.astro';
 import FootnoteBand from '../components/FootnoteBand.astro';

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,7 +1,0 @@
-/* Prototype-fidelity geometry shared by the Round 4+ implementation. The
-   principles and open-source pins are gone: content has moved on and stale
-   pixel heights only added dead space below the sections. */
-@media (min-width: 951px) {
-  .join-section > .network-split { min-height: 630px; }
-  .footnote-band { min-height: 234px; }
-}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -70,6 +70,7 @@
   --space-48: 48px;
   --space-56: 56px;
   --space-96: 96px;
+  --section-gap: 120px;
   --section-padding: 96px 48px;
   --font-display: "Newsreader", Georgia, serif;
   --font-body: "Geist", Helvetica, Arial, sans-serif;
@@ -1335,11 +1336,11 @@ kaos-graph, kaos-architecture { display: block; }
   .survey-island.compact .survey-bars { min-height: 403px; }
 }
 .home-section {
-  padding: 120px 48px 0;
+  padding: var(--section-gap) 48px 0;
   scroll-margin-top: 124px;
 }
 /* Trailing hydration scripts are main's real last children, so plain :last-child never matches the closing section. */
-main > .home-section:nth-last-child(1 of .home-section) { padding-bottom: 120px; }
+main > .home-section:nth-last-child(1 of .home-section) { padding-bottom: var(--section-gap); }
 .network-lists { display: grid; gap: 26px; grid-template-columns: 1fr 1fr; margin-top: 24px; }
 .network-lists > div { display: flex; flex-direction: column; gap: 8px; }
 .network-lists .eyebrow { color: rgba(244,242,238,.4); font-size: var(--mono-10); letter-spacing: .1em; margin-bottom: 4px; }
@@ -2089,6 +2090,7 @@ main > .home-section:nth-last-child(1 of .home-section) { padding-bottom: 120px;
 }
 
 @media (max-width: 950px) {
+  :root { --section-gap: 96px; }
   .hero {
     display: block;
     min-height: 700px;
@@ -2141,8 +2143,8 @@ main > .home-section:nth-last-child(1 of .home-section) { padding-bottom: 120px;
   .affiliations > .eyebrow { padding-inline: 24px; }
   .marquee-mask { mask-image: linear-gradient(90deg, transparent, #000 40px, #000 calc(100% - 40px), transparent); }
   .marquee-item { padding-inline: 28px; }
-  .home-section { padding: 96px 24px 0; }
-  main > .home-section:nth-last-child(1 of .home-section) { padding-bottom: 96px; }
+  .home-section { padding: var(--section-gap) 24px 0; }
+  main > .home-section:nth-last-child(1 of .home-section) { padding-bottom: var(--section-gap); }
   .phase-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .phase-card { min-height: 220px; }
   .principles-explorer-grid { gap: 32px; }


### PR DESCRIPTION
## Summary

- remove the two dead prototype `min-height` pins, delete `src/styles/layout.css`, and remove its `BaseLayout` import
- add `--section-gap` for the existing 120px desktop and 96px mobile homepage rhythm
- preserve the existing 32px mobile open-source override because changing it would move the section
- remove the completed CSS spacing cleanup item from `TODO.md`

## Pin measurements

Production-preview element heights in CSS pixels:

| Viewport | Element | Pin | With pin | Without pin | Finding |
| --- | --- | ---: | ---: | ---: | --- |
| 1440x1000 | `.join-section > .network-split` | 630px | 635px | 635px | natural content exceeds pin by 5px |
| 1440x1000 | `.footnote-band` | 234px | 279px | 279px | natural content exceeds pin by 45px |
| 420x900 | `.join-section > .network-split` | inactive | 1659.21875px | 1659.21875px | unchanged |
| 420x900 | `.footnote-band` | inactive | 615.34375px | 615.34375px | unchanged |

Selector-level screenshots had 0 changed pixels in all four comparisons, so neither rule earned relocation to an owning component.

## Section rhythm

`--section-gap` is defined beside the spacing tokens as 120px and overridden to 96px at widths up to 950px. `.home-section` top padding and the final homepage section's bottom padding now consume it without changing computed values.

The open-source homepage section remains a documented discrepancy at widths up to 950px: a later `.open-source-prototype` rule preserves its existing 32px padding. Standardising it to 96px would introduce a 64px movement and is outside this zero-visual-change refactor.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run check:ratchet`: `"passed": true`, 0 errors, 0 warnings, 0 hints
- `npm run build`
- masked full-page screenshots for `/`, `/network/`, `/contact/`, `/principles/`, and `/open-source/` at 1440x1000 and 420x900: 0 changed pixels for all ten before/after comparisons
- DOM gate for the same five routes at both viewports: both runs passed every route with no failures or errors
