### PR TITLE
Batch Dependabot version updates into a weekly grouped run

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+# Routine version updates arrive in one batch on Wednesday mornings rather than
+# as a trickle of single-package pull requests. Security updates are a separate
+# GitHub feature and are NOT governed by this schedule: they open as soon as an
+# advisory lands, which is the behaviour we want. The grouping below applies to
+# both, so a security batch also arrives as one pull request per group.
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: '06:00'
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    groups:
+      # Astro and its integrations move together; a split upgrade usually fails
+      # to build, so they belong in one pull request.
+      astro:
+        patterns:
+          - astro
+          - '@astrojs/*'
+      # Lint, format and type tooling: churny, low risk, and never worth a
+      # pull request each.
+      tooling:
+        patterns:
+          - eslint
+          - eslint-*
+          - '@eslint/*'
+          - '@typescript-eslint/*'
+          - prettier
+          - prettier-*
+          - typescript
+          - globals
+      # Everything else that is not a major bump. Majors stay individual so
+      # they can be read and tested on their own.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: '06:00'
+      timezone: Europe/Berlin
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
The repository had no `dependabot.yml`, so it received only security updates (one pull request per advisory) and no routine version updates at all.

This adds npm and GitHub Actions version updates on a **weekly Wednesday** schedule, grouped so a batch arrives as a few pull requests instead of one per package:

- **astro** — Astro and `@astrojs/*` together, since a split upgrade generally fails to build
- **tooling** — ESLint, Prettier, TypeScript and friends, churny and low risk
- **minor-and-patch** — everything else non-major
- Majors stay individual so they can be read and tested on their own
- GitHub Actions bumps all group into one

**Note on the premise:** the recent pull requests were not on a daily schedule. They were *security* updates, which GitHub opens as soon as an advisory lands and which no schedule can move (js-yaml 4.3.1 was a security release). That behaviour is left alone deliberately, but the grouping above applies to them too, so a multi-package advisory now arrives as one pull request per group rather than several.