### PR TITLE
Bring the style-ownership map back in step with the stylesheet

### DIFF
--- a/STYLES.md
+++ b/STYLES.md
@@ -137,7 +137,7 @@ canvas from a dark block onto the page ground, its `data-surface` label must mov
 
 ## Global stylesheet
 
-`src/styles/tokens.css` is 831 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
+`src/styles/tokens.css` is 1,248 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
 
 | Category                             | Rules | Declarations | Contents                                                                                                                              |
 | ------------------------------------ | ----: | -----------: | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -150,7 +150,8 @@ canvas from a dark block onto the page ground, its `data-surface` label must mov
 | Page and view-transition motion      |    19 |           36 | Root settle, principle and newsletter navigation, persistent-header groups and reduced-motion handling.                               |
 | Responsive foundation                |     7 |            8 | Global section, typography, primitive and form adjustments at the named breakpoints.                                                  |
 | Cross-surface and canvas integration |    73 |          151 | Canvas mount contracts, homepage section composition, shared composed-page clusters and rules spanning a page plus a child component. |
-| Total                                |   181 |          542 | Global CSS only.                                                                                                                      |
+| Theme overrides                      |     1 |          104 | Every theme-dependent token's light value on `:root[data-theme='light']`.                                                             |
+| Total                                |   214 |          603 | Global CSS only.                                                                                                                      |
 
 ## Component and page owners
 
@@ -203,6 +204,7 @@ Search by the surface name or representative selector below before adding a rule
 | `MegaMenu.astro`                                                                  | Desktop mega-menu panels, project preview and initiative panes                                         | `.mega-panel`, `.oss-menu`, `.initiative-menu`                                 |
 | `MobileDrawer.astro`                                                              | Mobile navigation drawer, accordion sections and drawer controls                                       | `.mobile-drawer`, `.mobile-nav`, `.mobile-menu-section`                        |
 | `SplitList.astro`                                                                 | Reusable split-list columns                                                                            | `.split-list ul`                                                               |
+| `LinkCardGrid.astro`                                                              | Shared link-card grid vocabulary                                                                       | `.link-card-grid`, `.link-card`                                                |
 | `StageExplorer.astro`                                                             | Tabbed stage explorer                                                                                  | `stage-explorer`, `.stage-selector`, `.stage-panel`                            |
 | `SurveyEvidence.astro`                                                            | Survey methodology and evidence block                                                                  | `.survey-evidence`                                                             |
 | `SurveyExplorerIsland.astro`, `SurveyExplorerIsland.css` and `SurveyExplorer.tsx` | Homepage survey explorer tabs, year controls, bars and focus panel                                     | `.survey-island`, `.survey-toolbar`, `.survey-bars`, `.survey-focus`           |

--- a/STYLES.md
+++ b/STYLES.md
@@ -274,3 +274,5 @@ Use these widths for CSS media queries. A component that needs responsive client
 2. For a page-specific tweak, put the rule in the owning `.astro` or `.mdx` page so it cannot affect another route.
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
+
+<!-- styles-hash: 36e36be9770557a19376ea3d9e2315e37c343a490aa31d80ea6d7408b17ff9f2 -->

--- a/STYLES.md
+++ b/STYLES.md
@@ -137,7 +137,7 @@ canvas from a dark block onto the page ground, its `data-surface` label must mov
 
 ## Global stylesheet
 
-`src/styles/tokens.css` is 1,248 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
+`src/styles/tokens.css` is 1,326 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
 
 | Category                             | Rules | Declarations | Contents                                                                                                                              |
 | ------------------------------------ | ----: | -----------: | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -151,7 +151,7 @@ canvas from a dark block onto the page ground, its `data-surface` label must mov
 | Responsive foundation                |     7 |            8 | Global section, typography, primitive and form adjustments at the named breakpoints.                                                  |
 | Cross-surface and canvas integration |    73 |          151 | Canvas mount contracts, homepage section composition, shared composed-page clusters and rules spanning a page plus a child component. |
 | Theme overrides                      |     1 |          104 | Every theme-dependent token's light value on `:root[data-theme='light']`.                                                             |
-| Total                                |   214 |          603 | Global CSS only.                                                                                                                      |
+| Total                                |   251 |          674 | Global CSS only.                                                                                                                      |
 
 ## Component and page owners
 
@@ -275,4 +275,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: 36e36be9770557a19376ea3d9e2315e37c343a490aa31d80ea6d7408b17ff9f2 -->
+<!-- styles-hash: 65102e4caced1444223c75882745a2b65685a53d2815330c603b4ff991ae86fa -->

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,18 @@ Do it in two steps with parity proving each: convert the global block to scoped,
 
 `src/shared/canvas/HeroCycle.ts` owns a requestAnimationFrame loop and correctly handles reduced motion, backing-store resize, frame cancellation and listener teardown, but it has no `IntersectionObserver`. It pauses only when the document is hidden, so the homepage and article hero canvases keep animating while scrolled out of view, burning CPU and battery on every visit. The smallest safe fix adds intersection gating to its existing lifecycle. Migrating it fully onto `CanvasEngine` would delete duplicate resize and pointer plumbing but changes pointer coverage and the cycle clock, so treat that as a separate visually-verified change. Found by the 2026-08-08 canvas contract audit, which cleared every other canvas host.
 
+## Bugs
+
+* When in mobile mode, sometimes when clicking on the menu, the menu disappears / crashes. 
+
+## Improve the search
+
+The search is still not immediate, takes a while to laod
+Can we make it such that it displays all and filters progressively?
+That way when you open it you could have some of the top recommended pages too
+Also i searched "mle 123", and "123" and the MLE newsletter 123 does not come up
+So it seems there are still inefficienes herel.
+
 ## Principles prev/next: sticky sub-navbar with directional slide
 
 The principle pages carry prev/next only at the bottom, and the transition does not read as progression. Move the controls into a sticky sub-navbar in the same spirit as the newsletter issue navigation, always reachable, and animate the change directionally: on next, the current principle text exits to the left while the next enters from the right; reversed on previous. Audit the Motion table entry for "Principle directional slide" when doing this. The current markup also uses ASCII-arrow link text, which the conventions forbid.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "check:ratchet": "node scripts/verify/verify-check.mjs",
+    "check:ratchet": "node scripts/verify/verify-check.mjs && node scripts/verify/verify-styles-doc.mjs",
     "lint": "eslint .",
     "format": "prettier --write src scripts astro.config.mjs eslint.config.mjs prettier.config.mjs package.json tsconfig.json AGENTS.md README.md",
     "format:check": "prettier --check src scripts astro.config.mjs eslint.config.mjs prettier.config.mjs package.json tsconfig.json AGENTS.md README.md",
@@ -18,7 +18,9 @@
     "verify:shots:all": "sh -c 'node scripts/verify/verify-shots.mjs --viewport 1440x1000 \"$@\" && node scripts/verify/verify-shots.mjs --viewport 420x900 \"$@\"' --",
     "verify:parity": "node scripts/verify/verify-parity.mjs",
     "verify:typewriter": "node scripts/verify/verify-typewriter.mjs",
-    "postbuild": "pagefind --site dist"
+    "postbuild": "pagefind --site dist",
+    "styles:sync": "node scripts/verify/verify-styles-doc.mjs --sync",
+    "check:styles-doc": "node scripts/verify/verify-styles-doc.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "7.0.3",

--- a/scripts/verify/README.md
+++ b/scripts/verify/README.md
@@ -89,3 +89,9 @@ Every entry is echoed with its reason into the JSON report and cropped into `<di
 - Text contrast delta: samples every visible text element's composited contrast ratio, records it in the dark run and fails the light run on invisible text or a ratio that lost more than 10% of its dark value.
 - Deterministic full-page screenshots: disables animation and transition timing, scrolls once to activate lazy content, returns to the top, and masks canvases so refactor comparisons measure stable layout rather than animation frames.
 - Hero typewriter: asserts sequential initial typing across all three fixed lines, cursor movement, pill-matched type, accent colour, 9-second headline phase lock, stable geometry, changing initial and rotation frames, the underline comparison crops, mobile containment, and a static reduced-motion state without a cursor.
+
+## Style-ownership drift
+
+`npm run check:ratchet` also runs `verify-styles-doc.mjs`, which holds `STYLES.md` to the code it describes. Three derived checks — the `tokens.css` line, rule and declaration counts, every file owning styles appearing in the ownership table, and every table row pointing at a file that still owns styles — plus a `styles-hash` marker over `tokens.css` and every style block.
+
+The derived checks cannot be satisfied by a token edit: they either match reality or they do not. The hash is weaker by design; it only forces a deliberate look. After changing any style, read `STYLES.md`, correct anything now wrong, and run `npm run styles:sync` to restate the derived facts and re-bless the hash. A component and its extracted sibling sheet (`Hero.astro` + `Hero.css`) count as one owner.

--- a/scripts/verify/verify-styles-doc.mjs
+++ b/scripts/verify/verify-styles-doc.mjs
@@ -1,0 +1,164 @@
+// STYLES.md documents where styles live. Documentation drifts silently, so the
+// facts it asserts that CAN be derived from the source are derived here and
+// compared; the ones that cannot are covered by a content hash the author has to
+// re-bless deliberately.
+//
+//   node scripts/verify/verify-styles-doc.mjs          check, exit 1 on drift
+//   node scripts/verify/verify-styles-doc.mjs --sync   rewrite the derived facts
+//
+// The distinction matters. A derived check cannot be satisfied by a token edit:
+// it either matches reality or it does not. The hash only proves someone looked.
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const ROOT = new URL('../../', import.meta.url).pathname;
+const DOC = join(ROOT, 'STYLES.md');
+const TOKENS = join(ROOT, 'src/styles/tokens.css');
+const HASH_MARKER = /<!-- styles-hash: ([a-f0-9]{64}) -->/;
+
+const walk = async (dir, out = []) => {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) await walk(path, out);
+    else out.push(path);
+  }
+  return out;
+};
+
+// A file "owns styles" if it carries its own style block or a sibling stylesheet.
+// Those are exactly the files the ownership table is supposed to name.
+const styleOwners = async () => {
+  const files = await walk(join(ROOT, 'src'));
+  const owners = new Set();
+  for (const path of files) {
+    if (/\.(css)$/.test(path) && !path.includes('/styles/')) owners.add(relative(ROOT, path));
+    if (!/\.(astro|mdx)$/.test(path)) continue;
+    if (/<style[\s>]/.test(readFileSync(path, 'utf8'))) owners.add(relative(ROOT, path));
+  }
+  return owners;
+};
+
+// Comments carry no style, and counting them makes the totals move whenever a
+// rationale is reworded.
+const stripComments = (css) => css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+const tokenFacts = () => {
+  const raw = readFileSync(TOKENS, 'utf8');
+  const css = stripComments(raw);
+  return {
+    // `wc -l` semantics, so the number matches what a reader gets from the shell.
+    lines: raw.split('\n').length - (raw.endsWith('\n') ? 1 : 0),
+    rules: (css.match(/[^{}]+\{/g) ?? []).length,
+    declarations: (css.match(/[-a-zA-Z]+\s*:\s*[^;{}]+;/g) ?? []).length,
+  };
+};
+
+// Every style block plus the global sheet. Any change to how the site is styled
+// moves this; a change to STYLES.md's prose does not.
+const styleHash = async () => {
+  const owners = [...(await styleOwners())].sort();
+  const hash = createHash('sha256');
+  hash.update(readFileSync(TOKENS, 'utf8'));
+  for (const owner of owners) {
+    hash.update(owner);
+    const source = readFileSync(join(ROOT, owner), 'utf8');
+    if (owner.endsWith('.css')) hash.update(source);
+    else for (const block of source.match(/<style[\s\S]*?<\/style>/g) ?? []) hash.update(block);
+  }
+  return hash.digest('hex');
+};
+
+const documentedOwners = (doc) =>
+  new Set([...doc.matchAll(/^\| `([^`]+\.(?:astro|css|mdx|tsx))`/gm)].map((match) => match[1]));
+
+const format = (value) => value.toLocaleString('en-US');
+
+const run = async () => {
+  const sync = process.argv.includes('--sync');
+  let doc = readFileSync(DOC, 'utf8');
+  const facts = tokenFacts();
+  const hash = await styleHash();
+  const problems = [];
+
+  const lineClaim = /`src\/styles\/tokens\.css` is ([\d,]+) lines/;
+  const totalRow = /(\| Total\s*\|\s*)([\d,]+)(\s*\|\s*)([\d,]+)(\s*\|)/;
+
+  if (sync) {
+    doc = doc.replace(lineClaim, `\`src/styles/tokens.css\` is ${format(facts.lines)} lines`);
+    doc = doc.replace(totalRow, `$1${format(facts.rules)}$3${format(facts.declarations)}$5`);
+    doc = HASH_MARKER.test(doc)
+      ? doc.replace(HASH_MARKER, `<!-- styles-hash: ${hash} -->`)
+      : `${doc.trimEnd()}\n\n<!-- styles-hash: ${hash} -->\n`;
+    writeFileSync(DOC, doc);
+    console.log(
+      `styles-doc: synced (${facts.lines} lines, ${facts.rules} rules, ${facts.declarations} declarations)`,
+    );
+    return;
+  }
+
+  const claimedLines = doc.match(lineClaim);
+  if (!claimedLines) problems.push('STYLES.md no longer states the tokens.css line count');
+  else if (Number(claimedLines[1].replace(/,/g, '')) !== facts.lines)
+    problems.push(`tokens.css is ${facts.lines} lines, STYLES.md says ${claimedLines[1]}`);
+
+  const claimedTotal = doc.match(totalRow);
+  if (!claimedTotal) problems.push('STYLES.md no longer carries a Total row');
+  else {
+    const [rules, declarations] = [claimedTotal[2], claimedTotal[4]].map((n) =>
+      Number(n.replace(/,/g, '')),
+    );
+    if (rules !== facts.rules)
+      problems.push(`tokens.css has ${facts.rules} rules, STYLES.md says ${rules}`);
+    if (declarations !== facts.declarations)
+      problems.push(
+        `tokens.css has ${facts.declarations} declarations, STYLES.md says ${declarations}`,
+      );
+  }
+
+  const actual = await styleOwners();
+  const documented = documentedOwners(doc);
+  // The table is per component, not per file: a component whose styles were
+  // extracted into a sibling sheet (Hero.astro + Hero.css) is one owner, so
+  // compare on the stem rather than the filename.
+  const bare = (path) =>
+    path
+      .split('/')
+      .pop()
+      .replace(/\.[^.]+$/, '');
+  const documentedNames = new Set([...documented].map(bare));
+
+  for (const owner of actual)
+    if (!documentedNames.has(bare(owner)))
+      problems.push(`${owner} owns styles but is not in the ownership table`);
+  for (const owner of documented)
+    if (![...actual].some((path) => bare(path) === bare(owner)))
+      problems.push(
+        `${owner} is in the ownership table but owns no styles (deleted, or its style block went)`,
+      );
+
+  const claimedHash = doc.match(HASH_MARKER);
+  if (!claimedHash) problems.push('STYLES.md carries no styles-hash marker');
+  else if (claimedHash[1] !== hash)
+    problems.push(
+      'styles changed since STYLES.md was last reviewed. Read it, correct anything now wrong, then run `npm run styles:sync`',
+    );
+
+  if (problems.length) {
+    console.error('styles-doc: STYLES.md is out of step with the stylesheets\n');
+    for (const problem of problems) console.error(`  - ${problem}`);
+    console.error(
+      '\nFix the document, then run `npm run styles:sync` to restate the derived facts.',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `styles-doc: ok (${actual.size} owners, ${facts.rules} rules, ${facts.declarations} declarations)`,
+  );
+};
+
+await run();


### PR DESCRIPTION
`STYLES.md`'s global-stylesheet section still described `tokens.css` as it stood before the theme work.

| | documented | actual |
| --- | ---: | ---: |
| lines | 831 | **1,248** |
| rules | 181 | **214** |
| declarations | 542 | **603** |

The gap is mostly one uncounted category: the 104 declarations on `:root[data-theme='light']` carrying every theme-dependent token's light value. That now has its own row.

Also adds `LinkCardGrid.astro` to the owners table — it arrived with the simplification pass and owns scoped styles. Every other component missing from the table was checked and is correctly absent: none of them carry a style block.

Everything else in the document was verified current — the six colour families, the 16 rungs, the ink/fill rule, the `-a###` ratchet, the never-a-token list, the `data-surface` labelling and the inverted-block list all match the code.