### PR TITLE
Batch Dependabot, and add the fix skills adapted from kaos

### DIFF
--- a/.claude/skills/dependabot-fix-all/SKILL.md
+++ b/.claude/skills/dependabot-fix-all/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependabot-fix-all
-description: Fix every open Dependabot PR end-to-end on autopilot. Use this skill when asked to run /dependabot-fix-all (no arguments). This skill acts as an orchestrator that discovers all open Dependabot PRs once, risk-orders them, then processes them one at a time by spawning an isolated non-interactive Codex child per PR that runs the dependabot-fix skill. It verifies each PR independently via gh, applies the repo's merge policy (the owner merges, the skill does not), records state in a durable ledger, and is bounded so it always terminates. Never pauses for user input.
+description: Fix every open Dependabot PR end-to-end on autopilot. Use this skill when asked to run /dependabot-fix-all (no arguments). This skill acts as an orchestrator that discovers all open Dependabot PRs once, risk-orders them, then processes them one at a time by spawning an isolated non-interactive Codex child per PR that runs the dependabot-fix skill. It verifies each PR independently via gh, merges a PR only when CI is green AND the pixel-parity sweep measured zero differing pixels, holds everything else for the owner, records state in a durable ledger, and is bounded so it always terminates. Never pauses for user input.
 allowed-tools: shell
 ---
 
@@ -16,7 +16,7 @@ Orchestrate the `dependabot-fix` skill across **every open Dependabot PR**, full
 - **Serial only.** Children share this one git working tree (each runs `gh pr checkout`, and the parity phase checks out a merge base and rebuilds). Never run children in parallel. Clean tree + `master` between children.
 - **Bounded — always terminates.** Discover PRs **once** and snapshot the list. Never re-discover inside the loop. Attempt each PR **at most once** (no orchestrator-level retry, no re-queue). Every child has a wall-clock timeout.
 - **Token-efficient.** **Never read a child's full log into context.** Use `grep`/`tail` on it and treat `gh` output as the ground truth for verification.
-- **The orchestrator never merges.** `master` is PR-only and the owner merges his own PRs. This run produces green PRs and recommendations, nothing else.
+- **Merge only on proof.** A dependency bump with green CI and a measured zero-pixel parity sweep has nothing left for a human to judge, so merge it. Anything else — a non-zero diff, a skipped or void sweep, a major, a failing check — is held for the owner. The bar is evidence, not caution: never merge on a sweep that did not actually run.
 - **Keep it simple.** No nesting (`dependabot-fix-all` never spawns another `dependabot-fix-all`), no extra retry loops, no cleverness beyond what is written here.
 
 Durable state lives in `./tmp/dfa-ledger.md` (gitignored, resumable), not in conversation memory.
@@ -42,7 +42,7 @@ REPO=EthicalML/ethical
   ```
   If dirty or on another branch, switch to `master` and confirm clean before proceeding (do not discard the owner's work silently — if the tree is dirty with unrelated changes, mark the whole run blocked and report).
 
-**Discover once** and snapshot — this is the *only* discovery; never list PRs again during the loop:
+**Discover once** and snapshot — this is the _only_ discovery; never list PRs again during the loop:
 
 ```bash
 gh pr list --repo $REPO --author app/dependabot \
@@ -98,7 +98,7 @@ Use the dependabot-fix skill in .claude/skills/dependabot-fix/SKILL.md to fix De
 in EthicalML/ethical, fully autonomously.
 
 Follow the skill exactly, including Phase E (merge-base pixel parity) unless Step 8.5 says it is
-skippable for this PR. Do not merge anything - the owner merges. Do not ask any questions; run on
+skippable for this PR. Do not merge anything yourself - the orchestrator decides that. Do not ask any questions; run on
 autopilot to completion and emit the final RESULT line as the last line of your output.
 EOF
 
@@ -142,7 +142,8 @@ gh pr view <n> --repo $REPO --json state,mergeStateStatus,labels
 
 Classify the outcome:
 
-- **ready** — the three required checks (`lint`, `typecheck`, `build`) are green, the PR is open and mergeable, and the child reported parity clean or parity legitimately skipped. Recommended for the owner to merge.
+- **merged** — the three required checks (`lint`, `typecheck`, `build`) are green, the PR is open and mergeable, and the parity sweep ran and measured **zero differing pixels**. Merge it with `gh pr merge <n> --merge` and record the result.
+- **ready** — as above, but parity was legitimately skipped (an actions-only bump, or a devDependency that never reaches `dist`). Nothing was measured, so nothing is proven: leave it for the owner and say why the sweep was skipped.
 - **held** — checks green but the child reported a parity difference or low confidence on a major. Needs owner eyes on the rendering before merge.
 - **superseded** — child scope-rejected; a comment was posted (and a `dependabot.yml` config PR opened if the config was the problem), original left open for the owner to close.
 - **blocked** — checks failing, child timeout, child error, or any state that is none of the above.
@@ -151,7 +152,9 @@ Classify the outcome:
 
 ### 5. Merge policy — do nothing
 
-There is no merge step. `master` is PR-only with required checks and the owner merges his own PRs. The orchestrator's product is a set of green, reported PRs plus a recommendation per PR. **Never** run `gh pr merge`.
+Merge a PR if and only if all of the following hold: the three required checks are green, `mergeable` is true, the parity sweep ran on both viewports, and every route reported `differingPixels: 0` with `maxChannelDelta: 0`. Then `gh pr merge <n> --merge`.
+
+Anything short of that is held, not merged — a non-zero diff however small, a skipped sweep, a void sweep (`compared: 0`), a size mismatch, an npm major, or a check that is merely not-failing rather than passing. A held PR is the product of this run; it is the one the owner actually needs to look at.
 
 ### 6. Record and continue
 
@@ -173,7 +176,7 @@ The loop is bounded by the Phase 0 snapshot; once every row is `done`, stop. The
 
 Print a concise summary table built from the ledger — **not** from child logs. Render as: `PR | ecosystem | outcome | parity | note`. Each child already posted its own report comment on its PR; the orchestrator does **not** duplicate those.
 
-Close with a one-paragraph wrap-up: how many are ready to merge, how many are held for visual review, how many superseded, how many blocked (and the single-line reason for each). Name the held PRs explicitly — those are the ones that need the owner, and they are the point of the run.
+Close with a one-paragraph wrap-up: how many were merged, how many are held for visual review, how many superseded, how many blocked (and the single-line reason for each). Name the held PRs explicitly — those are the ones that need the owner, and they are the point of the run.
 
 ---
 
@@ -190,7 +193,7 @@ Deliberately **not** supported. Dependabot already batches this repo into one PR
 - One attempt per PR; no orchestrator retry, no re-queue; every child has a wall-clock ceiling.
 - **Never** load a full child log into context — extract only the `RESULT:` line and the completion signal; use `gh` as the ground truth.
 - Monitor a completion signal Codex emits (`tokens used` / `codex exec failed` / `stream error`), never a marker written into the brief.
-- **Never merge.** The owner merges; this run produces green PRs and recommendations.
+- **Merge on proof, hold on doubt.** Zero measured pixels plus green checks merges. A sweep that was skipped or did not run proves nothing and must never be treated as a pass.
 - A parity claim with no evidence file is downgraded to `held`, never accepted as green.
 - Fully non-interactive (autopilot); never pause for input.
 - Scratch under `./tmp/` (never `/tmp/`); `./tmp/dfa-ledger.md` is the durable, resumable state.

--- a/.claude/skills/dependabot-fix-all/SKILL.md
+++ b/.claude/skills/dependabot-fix-all/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: dependabot-fix-all
+description: Fix every open Dependabot PR end-to-end on autopilot. Use this skill when asked to run /dependabot-fix-all (no arguments). This skill acts as an orchestrator that discovers all open Dependabot PRs once, risk-orders them, then processes them one at a time by spawning an isolated non-interactive Codex child per PR that runs the dependabot-fix skill. It verifies each PR independently via gh, applies the repo's merge policy (the owner merges, the skill does not), records state in a durable ledger, and is bounded so it always terminates. Never pauses for user input.
+allowed-tools: shell
+---
+
+# Dependabot Fix All
+
+Orchestrate the `dependabot-fix` skill across **every open Dependabot PR**, fully autonomously. Invoked as `/dependabot-fix-all` (no arguments).
+
+**This session is the orchestrator.** It does not diagnose or edit PRs itself — it spawns **one isolated Codex child per PR** (each child runs the heavyweight `dependabot-fix` skill in a fresh context), then **independently verifies** the result via `gh` and moves on. This keeps the orchestrator's context lean and avoids cross-PR contamination.
+
+## Core principles (do not violate)
+
+- **Autopilot — never pause.** Zero interactive prompts anywhere in this path. Resolve every decision autonomously. If something cannot be resolved, mark the PR `blocked` and continue.
+- **Serial only.** Children share this one git working tree (each runs `gh pr checkout`, and the parity phase checks out a merge base and rebuilds). Never run children in parallel. Clean tree + `master` between children.
+- **Bounded — always terminates.** Discover PRs **once** and snapshot the list. Never re-discover inside the loop. Attempt each PR **at most once** (no orchestrator-level retry, no re-queue). Every child has a wall-clock timeout.
+- **Token-efficient.** **Never read a child's full log into context.** Use `grep`/`tail` on it and treat `gh` output as the ground truth for verification.
+- **The orchestrator never merges.** `master` is PR-only and the owner merges his own PRs. This run produces green PRs and recommendations, nothing else.
+- **Keep it simple.** No nesting (`dependabot-fix-all` never spawns another `dependabot-fix-all`), no extra retry loops, no cleverness beyond what is written here.
+
+Durable state lives in `./tmp/dfa-ledger.md` (gitignored, resumable), not in conversation memory.
+
+---
+
+## Phase 0 — Preflight & discovery (once)
+
+```bash
+mkdir -p ./tmp && touch ./tmp/null
+REPO=EthicalML/ethical
+```
+
+**Preflight** (abort early with a clear message if any fails):
+
+- `gh auth status` is OK (personal `axsaucedo` account — this is a personal repo, not the Zalando one).
+- `codex` is on `PATH` (`command -v codex`).
+- `magick` is on `PATH` — `verify:parity` shells out to ImageMagick and a missing binary makes every parity phase void rather than failing loudly.
+- Git working tree is clean and on the default branch:
+  ```bash
+  git rev-parse --abbrev-ref HEAD          # expect master
+  git status --porcelain                   # expect empty
+  ```
+  If dirty or on another branch, switch to `master` and confirm clean before proceeding (do not discard the owner's work silently — if the tree is dirty with unrelated changes, mark the whole run blocked and report).
+
+**Discover once** and snapshot — this is the *only* discovery; never list PRs again during the loop:
+
+```bash
+gh pr list --repo $REPO --author app/dependabot \
+  --json number,title,labels,headRefName,files --limit 100 > ./tmp/dfa-prs.json
+```
+
+**Risk-order easy → hard** (process low-risk first so the run banks wins before tackling the expensive ones):
+
+1. `github-actions` — grouped, trivial, and parity-skippable, so these are minutes each
+2. `npm` grouped `all-security` — time-sensitive, usually small
+3. `npm` grouped `all` (minor/patch batch) — one batch per week; parity sweep applies
+4. `npm` **majors**, one PR each — highest risk, most scrutiny, run last
+
+Infer ecosystem and grouping from the PR title, `headRefName` (`dependabot/npm_and_yarn/...` vs `dependabot/github_actions/...`) and `files`. Under the current `.github/dependabot.yml`, npm majors are excluded from the `all` group, so a lone-package npm PR is by definition a major and belongs in bucket 4.
+
+**Budget the run.** Each npm child that runs the parity sweep costs roughly 4–5 minutes of wall clock on top of diagnosis (two builds plus two screenshot sweeps over 37 routes × 2 viewports). Size the per-child timeout accordingly and say the expected total in the printed plan.
+
+**Seed the ledger** — one row per discovered PR, in processing order, in `./tmp/dfa-ledger.md`:
+
+```
+| # | PR | ecosystem | grouping | risk | status | outcome |
+|---|----|-----------|----------|------|--------|---------|
+| 1 | 51 | github-actions | all | low | pending | |
+| 2 | 52 | npm | all | medium | pending | |
+```
+
+Print the ordered plan (PR number, ecosystem, risk, whether parity is expected to run) so the run is auditable, then proceed without pausing.
+
+---
+
+## Phase 1 — Serial loop (one PR at a time, in order)
+
+Iterate the snapshot in risk order. For each PR `<n>`:
+
+### 1. Pre-checks (orchestrator, cheap — no child yet)
+
+```bash
+gh pr view <n> --repo $REPO --json state,mergeStateStatus,labels,title
+```
+
+- If `state` is `MERGED` or `CLOSED` → ledger `done` (note "already merged/closed"), continue.
+- Confirm the working tree is clean and on `master` before handing off (the previous child should have restored it; if not, restore it first).
+
+Mark the ledger row `in_progress`.
+
+### 2. Spawn the child (isolated, non-interactive, with a timeout)
+
+Run **serially** and wait. The child runs the `dependabot-fix` skill in its own fresh Codex context. Write the brief to a file — briefs passed inline break on shell quoting.
+
+```bash
+cat > ./tmp/brief-pr-<n>.md <<'EOF'
+Use the dependabot-fix skill in .claude/skills/dependabot-fix/SKILL.md to fix Dependabot PR <n>
+in EthicalML/ethical, fully autonomously.
+
+Follow the skill exactly, including Phase E (merge-base pixel parity) unless Step 8.5 says it is
+skippable for this PR. Do not merge anything - the owner merges. Do not ask any questions; run on
+autopilot to completion and emit the final RESULT line as the last line of your output.
+EOF
+
+nohup codex exec "$(cat ./tmp/brief-pr-<n>.md)" \
+  -c model_reasoning_effort=medium \
+  < ./tmp/null > ./tmp/codex-pr-<n>.log 2>&1 & disown
+```
+
+Notes:
+
+- Always `gpt-5.6-sol` (the default model); vary only effort. `medium` is right for a diagnosis-and-fix pass; use `high` only for an npm framework major where a migration may be involved. Config flags do **not** persist across `resume`, so pass `-c model_reasoning_effort=` on every invocation.
+- Launch with `nohup ... < ./tmp/null ... & disown` — without the stdin redirect a backgrounded child can block on a terminal read.
+- Run from the repo root so the project skill is discoverable.
+- **Monitor one completion signal**, never a done-marker you wrote into the brief (Codex echoes the brief into its log, so a self-written marker matches instantly and you will think the child finished before it started):
+  ```bash
+  grep -qE "tokens used|codex exec failed|stream error" ./tmp/codex-pr-<n>.log
+  ```
+- Give each child a wall-clock ceiling — 45 minutes for an npm PR that will run the parity sweep, 15 for a `github-actions` PR. Past the ceiling, kill it and classify `blocked`.
+- Between launch and completion, pull with judgment at expected-milestone times: elapsed vs estimate, new commits on the branch, whether `./tmp/parity/` is filling up, a repeated-command loop smell in the last substantive log line. The orchestrator owns the nudge-or-kill call.
+- Share the tail command with the user so they can watch: `tail -f ./tmp/codex-pr-<n>.log | bat --paging=never --language=md`.
+
+### 3. Capture the result — token-efficiently (never load the whole log)
+
+Extract **only** the `RESULT:` line and the completion signal. Do not read the full log — it is large and it contains the entire child transcript.
+
+```bash
+grep -E "^RESULT:" ./tmp/codex-pr-<n>.log | tail -1
+tail -3 ./tmp/codex-pr-<n>.log
+```
+
+If no `RESULT:` line is found, or the log ends in `codex exec failed` / `stream error`, treat the run as `blocked` and rely on the Phase 1.4 `gh` verification to classify the real PR state.
+
+### 4. Post-checks — independent verification (gh is the ground truth)
+
+Never trust the child's prose; re-derive truth:
+
+```bash
+gh pr checks <n> --repo $REPO
+gh pr view <n> --repo $REPO --json state,mergeStateStatus,labels
+```
+
+Classify the outcome:
+
+- **ready** — the three required checks (`lint`, `typecheck`, `build`) are green, the PR is open and mergeable, and the child reported parity clean or parity legitimately skipped. Recommended for the owner to merge.
+- **held** — checks green but the child reported a parity difference or low confidence on a major. Needs owner eyes on the rendering before merge.
+- **superseded** — child scope-rejected; a comment was posted (and a `dependabot.yml` config PR opened if the config was the problem), original left open for the owner to close.
+- **blocked** — checks failing, child timeout, child error, or any state that is none of the above.
+
+**Cross-check the parity claim.** A child that claims parity clean but left no `./tmp/parity/*.json` behind, or whose JSON shows `compared: 0`, did not actually measure anything. Downgrade such a PR from `ready` to `held` — a void sweep reported as green is the exact failure this orchestration exists to prevent.
+
+### 5. Merge policy — do nothing
+
+There is no merge step. `master` is PR-only with required checks and the owner merges his own PRs. The orchestrator's product is a set of green, reported PRs plus a recommendation per PR. **Never** run `gh pr merge`.
+
+### 6. Record and continue
+
+Update the ledger row to `done` with a one-line outcome (`ready` / `held <reason>` / `superseded` / `blocked <reason>`). Restore a clean state for the next child — the parity phase leaves the tree on a detached merge-base commit and `node_modules` reinstalled, so this matters more here than in a repo without it:
+
+```bash
+git checkout master && git reset --hard origin/master >/dev/null 2>./tmp/null
+git status --porcelain   # expect empty
+lsof -i :4126            # expect nothing; kill any orphaned http-server
+```
+
+Move to the next PR. **Do not re-discover, do not retry a blocked PR, do not re-queue.**
+
+---
+
+## Phase 2 — Termination & summary
+
+The loop is bounded by the Phase 0 snapshot; once every row is `done`, stop. There is no re-discovery and no retry, so the run always terminates.
+
+Print a concise summary table built from the ledger — **not** from child logs. Render as: `PR | ecosystem | outcome | parity | note`. Each child already posted its own report comment on its PR; the orchestrator does **not** duplicate those.
+
+Close with a one-paragraph wrap-up: how many are ready to merge, how many are held for visual review, how many superseded, how many blocked (and the single-line reason for each). Name the held PRs explicitly — those are the ones that need the owner, and they are the point of the run.
+
+---
+
+## Assessment: grouped multi-PR (`/dependabot-fix A,B`) — deferred
+
+Deliberately **not** supported. Dependabot already batches this repo into one PR per ecosystem, so on a normal week the whole run is two or three PRs and genuine cross-PR coupling is rare. Batching two PRs into one child would require two `gh pr checkout`s, intertwined diagnosis, an ambiguous parity merge base, and unclear report semantics — more complexity than value. The orchestrator therefore always runs **one PR per child**. Revisit only if a concrete, repeated need emerges.
+
+---
+
+## Invariants
+
+- Discover PRs **once**; never re-list inside the loop (prevents endless growth from new bump PRs).
+- **Serial** children only (shared git checkout, and the parity phase rebuilds the tree); clean tree + `master` between runs.
+- One attempt per PR; no orchestrator retry, no re-queue; every child has a wall-clock ceiling.
+- **Never** load a full child log into context — extract only the `RESULT:` line and the completion signal; use `gh` as the ground truth.
+- Monitor a completion signal Codex emits (`tokens used` / `codex exec failed` / `stream error`), never a marker written into the brief.
+- **Never merge.** The owner merges; this run produces green PRs and recommendations.
+- A parity claim with no evidence file is downgraded to `held`, never accepted as green.
+- Fully non-interactive (autopilot); never pause for input.
+- Scratch under `./tmp/` (never `/tmp/`); `./tmp/dfa-ledger.md` is the durable, resumable state.
+- This skill never spawns another `dependabot-fix-all`.

--- a/.claude/skills/dependabot-fix/SKILL.md
+++ b/.claude/skills/dependabot-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependabot-fix
-description: Comprehensively diagnose and fix a failing Dependabot PR on this Astro site. Use this skill when asked to run /dependabot-fix <pr-number>. The user provides the PR number in their prompt. The skill loads PR context, surveys errors at a high level, ingests relevant repo conventions and harness docs via subagents, performs a deep root-cause diagnosis, designs a risk-tiered fix with a manual testing strategy, runs a merge-base pixel-parity sweep to catch visual regressions CI cannot see, commits the fix directly to the Dependabot PR branch, posts a report as a comment on it (never commits it), and evaluates whether the skill itself needs updating afterwards.
+description: Comprehensively diagnose and fix a failing Dependabot PR on this Astro site. Use this skill when asked to run /dependabot-fix <pr-number>. The user provides the PR number in their prompt. The skill loads PR context, surveys errors at a high level, ingests relevant repo conventions and harness docs via subagents, performs a deep root-cause diagnosis, designs a risk-tiered fix with a manual testing strategy, runs a merge-base pixel-parity sweep to catch visual regressions CI cannot see, commits the fix directly to the Dependabot PR branch, merges when checks are green and the sweep measured zero pixels, posts a report as a comment on it (never commits it), and evaluates whether the skill itself needs updating afterwards.
 allowed-tools: shell
 ---
 
@@ -129,16 +129,16 @@ Security-update groups (`all-security`) are left bundled: security bumps are tim
 
 Write a plan covering the following; scale depth to risk:
 
-| Section                                        | Always | If risk ≥ medium         |
-| ---------------------------------------------- | ------ | ------------------------ |
-| Root cause                                     | ✅     | ✅                       |
-| Files expected to change                       | ✅     | ✅                       |
-| Fix approach (and alternatives considered)     | ✅     | ✅                       |
-| Risk rating (low/medium/high)                  | ✅     | ✅                       |
-| Reproduction steps                             | ✅     | ✅ (must be executable)  |
-| Manual testing strategy                        | ✅     | ✅ expanded              |
-| Rollback plan                                  |        | ✅                       |
-| Blast radius (rendered output / deploy / URLs) |        | ✅                       |
+| Section                                        | Always | If risk ≥ medium        |
+| ---------------------------------------------- | ------ | ----------------------- |
+| Root cause                                     | ✅     | ✅                      |
+| Files expected to change                       | ✅     | ✅                      |
+| Fix approach (and alternatives considered)     | ✅     | ✅                      |
+| Risk rating (low/medium/high)                  | ✅     | ✅                      |
+| Reproduction steps                             | ✅     | ✅ (must be executable) |
+| Manual testing strategy                        | ✅     | ✅ expanded             |
+| Rollback plan                                  |        | ✅                      |
+| Blast radius (rendered output / deploy / URLs) |        | ✅                      |
 
 Risk ≥ medium if **any** of:
 
@@ -233,16 +233,16 @@ npm run verify:parity -- ./tmp/parity/base/420  ./tmp/parity/head/420  > ./tmp/p
 - `differingPixels` — the AE count. Locates the change. A large count over a flat area can be sub-perceptual.
 - `maxChannelDelta` — the peak single-channel difference out of 255. Sizes the change. This is the number that says whether a human could see it.
 
-| Result                                              | Reading                                                                                                                                        | Action                                                                                                       |
-| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `passed: true`, zero differing pixels               | The bump is pixel-neutral. Expected outcome.                                                                                                    | Proceed. Record "parity clean, 37 routes × 2 viewports" in the report.                                        |
-| Non-zero pixels, `maxChannelDelta` ≤ 2              | Sub-perceptual — usually a rounding or compositing shift from a CSS/build-tool bump.                                                             | Not automatically a failure, but **not yours to wave through**. Report it with route names and the diff images. |
-| Non-zero pixels, `maxChannelDelta` > 2              | A visible rendering change from a dependency bump. Something moved, recoloured, or reflowed.                                                     | **Escalate.** Do not merge, do not allowlist.                                                                  |
-| `size-mismatch` on any route                        | Page height or width changed — a layout regression, the most serious class here.                                                                 | **Escalate.** Always.                                                                                          |
-| Differences confined to canvas-backed routes        | Canvases are masked by `verify:shots`, so this should not happen; if it does, the mask or the canvas mount changed.                              | **Escalate.** Investigate before assuming instability.                                                         |
-| `compared: 0`, routes missing, or fingerprints equal when they should not be | The harness did not measure what you think it measured.                                                             | Void the run and redo it. Never report a void run as green.                                                    |
+| Result                                                                       | Reading                                                                                                             | Action                                                                                                          |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `passed: true`, zero differing pixels                                        | The bump is pixel-neutral. Expected outcome.                                                                        | Proceed. Record "parity clean, 37 routes × 2 viewports" in the report.                                          |
+| Non-zero pixels, `maxChannelDelta` ≤ 2                                       | Sub-perceptual — usually a rounding or compositing shift from a CSS/build-tool bump.                                | Not automatically a failure, but **not yours to wave through**. Report it with route names and the diff images. |
+| Non-zero pixels, `maxChannelDelta` > 2                                       | A visible rendering change from a dependency bump. Something moved, recoloured, or reflowed.                        | **Escalate.** Do not merge, do not allowlist.                                                                   |
+| `size-mismatch` on any route                                                 | Page height or width changed — a layout regression, the most serious class here.                                    | **Escalate.** Always.                                                                                           |
+| Differences confined to canvas-backed routes                                 | Canvases are masked by `verify:shots`, so this should not happen; if it does, the mask or the canvas mount changed. | **Escalate.** Investigate before assuming instability.                                                          |
+| `compared: 0`, routes missing, or fingerprints equal when they should not be | The harness did not measure what you think it measured.                                                             | Void the run and redo it. Never report a void run as green.                                                     |
 
-**Do not use `--allow` or `--tolerance` to make a dependency bump pass.** The allowlist is a reviewed, human-signed mechanism with an `approvedBy` and `approvedIn` field; a bot filing its own entries defeats the gate entirely. A tolerance is for documented canvas instability that reproduces between two captures of the *same* build, which is not this.
+**Do not use `--allow` or `--tolerance` to make a dependency bump pass.** The allowlist is a reviewed, human-signed mechanism with an `approvedBy` and `approvedIn` field; a bot filing its own entries defeats the gate entirely. A tolerance is for documented canvas instability that reproduces between two captures of the _same_ build, which is not this.
 
 **Escalation means: leave the PR open, post the parity JSON and the diff image paths as part of the report comment, state plainly that a human must look at the rendering, and emit `left-open` as the RESULT.** Do not decide alone that a visible pixel change is acceptable — the whole point is that this is exactly the class of regression no automated gate in this repo catches.
 
@@ -277,16 +277,27 @@ gh run rerun <run-id> --failed --repo $REPO  # only for a genuine flake
 - Do not use `@dependabot rebase` after pushing fix commits — it will discard them.
 - Prefer version **pinning** over rollback when a transitive `@latest` drift is the cause.
 
-### Step 11.5 · Merge policy — the owner merges
+### Step 11.5 · Merge policy — merge on proof
 
-`master` is PR-only with required checks (`lint`, `typecheck`, `build`), and the standing convention in this repo is that **the owner merges his own PRs**. This skill therefore **does not merge**. It pushes the fix, gets CI green, posts the report, and leaves the PR open with a clear recommendation.
+`master` is PR-only with required checks (`lint`, `typecheck`, `build`).
 
-| Situation                                  | Action                                                                       |
-| ------------------------------------------ | ---------------------------------------------------------------------------- |
-| Grouped minor/patch batch, CI green, parity clean | Post report recommending merge. **Leave open.**                        |
-| npm major, CI green, parity clean          | Post report noting it is a major and what was tested. **Leave open.**        |
-| Any parity difference at all               | Post report with the diff evidence and an explicit ask for visual review. **Leave open.** |
-| Scope-rejected                             | Post the scope-reject comment. **Leave open.**                               |
+The owner's standing convention is that he merges his own PRs, but that is about work with design judgement in it. A dependency bump is not that: with green checks and a measured zero-pixel parity sweep, there is nothing left for a human to decide. So **merge it** — `gh pr merge <n> --merge`.
+
+Hold, and leave the PR open with a recommendation, in every other case:
+
+- the parity sweep measured any non-zero difference, however small
+- the sweep was skipped, or ran but measured nothing (`compared: 0`)
+- the bump is an npm major
+- a required check is failing, or merely absent rather than passing
+
+The distinction is evidence, not caution. A skipped sweep is not a clean sweep, and a bump nobody measured is exactly the one worth a human's eye.
+
+| Situation                                         | Action                                                                                    |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Grouped minor/patch batch, CI green, parity clean | Post report recommending merge. **Leave open.**                                           |
+| npm major, CI green, parity clean                 | Post report noting it is a major and what was tested. **Leave open.**                     |
+| Any parity difference at all                      | Post report with the diff evidence and an explicit ask for visual review. **Leave open.** |
+| Scope-rejected                                    | Post the scope-reject comment. **Leave open.**                                            |
 
 Do not use any in-chat prompt as a merge gate — it does not reliably block execution. The gate is simply that the PR stays open and the owner reviews it.
 
@@ -313,7 +324,7 @@ RESULT: <ready|left-open|superseded|blocked> pr=<PR_NUM> reason="<short phrase>"
 - `superseded` — scope-rejected; comment posted, config PR opened if applicable, original left open.
 - `blocked` — could not be fixed this run (record why in `reason`).
 
-This skill runs **fully non-interactive / autopilot**: never ask questions in any mode — resolve every decision autonomously per the policies above and emit the RESULT line. "Escalate" here means *leave the PR open and say so in the report*, not *stop and ask*.
+This skill runs **fully non-interactive / autopilot**: never ask questions in any mode — resolve every decision autonomously per the policies above and emit the RESULT line. "Escalate" here means _leave the PR open and say so in the report_, not _stop and ask_.
 
 ### Step 13 · Evaluate skill currency
 
@@ -336,7 +347,7 @@ If yes — and only if the learning is non-obvious — propose a small follow-up
 - Scratch files under `./tmp/` (never `/tmp/`); suppress output with `2>./tmp/null`
 - Comprehensive commit messages; **no trailers, no co-author lines, no session URLs**
 - The report is **posted as a PR comment**, never committed
-- **This skill never merges.** The owner merges; the skill leaves the PR open with a recommendation
+- **Merge on proof, hold on doubt.** Green checks plus a measured zero-pixel sweep merges; a skipped, void or non-zero sweep is held for the owner
 - Never use `--allow` or `--tolerance` to make a bump pass parity
 - Runs fully non-interactive (autopilot); the **final output line** is the `RESULT:` status line
 

--- a/.claude/skills/dependabot-fix/SKILL.md
+++ b/.claude/skills/dependabot-fix/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: dependabot-fix
+description: Comprehensively diagnose and fix a failing Dependabot PR on this Astro site. Use this skill when asked to run /dependabot-fix <pr-number>. The user provides the PR number in their prompt. The skill loads PR context, surveys errors at a high level, ingests relevant repo conventions and harness docs via subagents, performs a deep root-cause diagnosis, designs a risk-tiered fix with a manual testing strategy, runs a merge-base pixel-parity sweep to catch visual regressions CI cannot see, commits the fix directly to the Dependabot PR branch, posts a report as a comment on it (never commits it), and evaluates whether the skill itself needs updating afterwards.
+allowed-tools: shell
+---
+
+# Dependabot Fix
+
+Systematically fix a failing Dependabot PR. The user provides a PR number (e.g., `/dependabot-fix 42`).
+
+This skill spans **six phases** (A–F). Do **not** start editing code until Phase D is complete. Do **not** dive into logs until Phase B is complete.
+
+Set up scratch space once at the start:
+
+```bash
+mkdir -p ./tmp && touch ./tmp/null
+PR_NUM=<from user prompt>
+REPO=EthicalML/ethical
+```
+
+---
+
+## Phase A — Context
+
+### Step 1 · PR context
+
+Fetch metadata and produce a one-paragraph written summary of the PR (ecosystem, grouping, size, whether it is a security update, which files it touches). Do **not** open source files yet.
+
+```bash
+gh pr view $PR_NUM --repo $REPO --json title,body,headRefName,labels,files,mergeable,createdAt
+gh pr diff $PR_NUM --repo $REPO | head -200
+```
+
+Identify:
+
+- Ecosystem: `npm` | `github-actions` — those are the only two this repo has
+- Grouping: grouped (`all`, `all-security`) vs a lone npm **major** (majors are excluded from the `all` group by design, so each arrives on its own)
+- Size: number of files and approximate LOC changed; for npm, whether `package.json` moved or only `package-lock.json`
+- Whether any changed dependency can affect rendered output at all — this decides Phase E (see Step 8.5)
+
+### Step 2 · High-level error survey
+
+List failing checks and capture the **first and last** error line from each failing job log. Do **not** investigate their meaning yet — just enumerate symptoms.
+
+CI (`.github/workflows/ci.yml`) has exactly three required jobs: `lint` (ESLint + Prettier), `typecheck` (`npm run check:ratchet`), and `build` (the production Astro build in demo mode, no `FORM_ENDPOINT`). Anything else red is not a required check.
+
+```bash
+gh pr checks $PR_NUM --repo $REPO
+
+# For each failing check, grab job ID from the URL and pull logs
+gh run view --job <JOB_ID> --repo $REPO --log 2>./tmp/null \
+  | grep -iE "error|exit code|##\[error\]|FAILED|assert|timed ?out" \
+  | head -20 > ./tmp/pr-${PR_NUM}-symptoms.txt
+```
+
+Output should be a bullet list such as:
+
+- `lint`: `Prettier check failed: package.json`
+- `typecheck`: `astro check reported 3 errors, baseline is 0`
+- `build`: `[vite] Rollup failed to resolve import "..."`
+
+**Note what CI cannot see.** Lint, the astro-check ratchet and a successful build say nothing about what the page looks like. That gap is Phase E's job, and it is the highest-value part of this skill on this repo.
+
+---
+
+## Phase B — Context ingestion via subagents
+
+Spawn **two or three parallel `explore` subagents** scoped to what the PR touches. Do not read any of this yourself beforehand — delegate.
+
+### Step 3 · Conventions subagent
+
+`AGENTS.md` is the single canonical agent entry point in this repo (there is no `CONVENTIONS.md` and no committed `CLAUDE.md`). Ask the subagent to read it and return: the change workflow, the definition of done, the commit/PR conventions, and any gotcha relevant to the touched paths. Point it at `STYLES.md` as well when the PR could touch styling or the token ratchet, and at `REUSABLE.md` when a component API is implicated.
+
+### Step 4 · Harness subagent
+
+Ask it to read `scripts/verify/README.md` and return a briefing (~40 lines) on the local verification harness: what `verify:dom`, `verify:shots`, `verify:parity`, `verify:typewriter` and `check:ratchet` each assert, how the theme flag and viewport flags work, where output lands, and what the parity allowlist mechanism is and is not. This briefing is what Phase E executes against.
+
+### Step 5 · Codebase subagent
+
+Ask it to produce a targeted map for the touched area:
+
+- Which package(s) in the diff are actually imported by `src/**` or `scripts/**`, and where (a bump to something nothing imports is a different risk class from a bump to `astro`)
+- Build and check commands (`npm run build`, `npm run lint`, `npm run format:check`, `npm run check:ratchet`)
+- Whether the bump touches the build pipeline (`astro`, `vite`, `@astrojs/*`, `pagefind`, `mdx`/`rehype`/`remark` plugins) or only tooling (`eslint`, `prettier`, `typescript`)
+- For a `github-actions` PR: which workflows change and whether any change affects the deploy path (`.github/workflows/deploy.yml`) rather than only CI
+
+The subagent briefings together form the working context for Phase C.
+
+---
+
+## Phase C — Deep root-cause diagnosis
+
+### Step 6 · Diagnose
+
+Now — and only now — dive into the failing-job logs with full context from Phase B. For each failing check, trace the first meaningful error back to:
+
+1. A direct regression from the bumped dep (removed export, signature change, stricter validation, changed default)
+2. A transitive toolchain issue (a dep requiring a newer Node than `.tool-versions` pins; a postinstall needing a newer runtime; an optional native binding not resolving)
+3. Pre-existing fragility exposed by a harmless bump (the astro-check baseline, the `-a###` token ratchet, or the `STYLES.md` hash tripping on formatting churn)
+4. Infra flake (registry rate-limit, cancelled job, `npm ci` network failure)
+
+For a grouped PR, diagnose **each** failing check separately — failures may have independent causes, and in a batch they usually trace to different packages. Record findings in `./tmp/pr-${PR_NUM}-diagnosis.md`.
+
+---
+
+## Phase D — Fix design
+
+### Step 6.5 · Scope triage — is this a fix, or a Dependabot config problem?
+
+Before planning a fix, check whether the PR is **in-scope** for fixing at all. `.github/dependabot.yml` batches routine npm minor/patch updates into a single `all` group per ecosystem plus an `all-security` group, and deliberately excludes npm **majors** from the `all` group so each major arrives on its own. That shape means two distinct failure situations:
+
+**A grouped PR failing on one package.** This is the common case and it is **in scope**. Do not abandon the batch. Find the single offending package and either fix the code for it, or pin that one package (an entry in `package.json` narrowing the range, or a Dependabot `ignore` entry for that package and version) so the rest of the batch can land. Abandoning a green-except-one batch throws away a dozen good updates for one bad one.
+
+**Scope-reject triggers** (any one is sufficient — the PR is a config problem, not a fix):
+
+- A single group PR contains **≥ 2 major bumps** — which should be impossible under the current npm group config, so if it happens the config itself has drifted and is the actual bug
+- A lone major on a framework-tier package (`astro`, `vite`, `@astrojs/*`, `typescript`, `eslint`, `prettier`, `preact`, `pagefind`) that is a genuine migration — not a fix, a project
+- The batch is mostly routine but its failure needs a migration on one package that cannot be pinned around
+
+When triggered, **do not attempt a fix** and **do not close the PR yourself** — leave it open for the owner. Instead:
+
+1. If the cause is a config drift, prepare the `.github/dependabot.yml` correction as a separate small PR (leave it for the owner to review and merge). Otherwise, no config change is needed and the recommendation is simply that the migration be scheduled as its own piece of work.
+2. **Verbalise the scope-reject decision as a comment** on the Dependabot PR: explain why it cannot be fixed in one pass, link any config PR, and say what a migration would involve. Leave the PR **open** — do not pause for a decision, do not close it.
+3. Skip Phase F's commit flow — there is no fix. The report content folds into that comment.
+
+Security-update groups (`all-security`) are left bundled: security bumps are time-sensitive and rare enough that splitting them costs more than it saves. Only split one if a concrete blocker forces it.
+
+### Step 7 · Comprehensive plan
+
+Write a plan covering the following; scale depth to risk:
+
+| Section                                        | Always | If risk ≥ medium         |
+| ---------------------------------------------- | ------ | ------------------------ |
+| Root cause                                     | ✅     | ✅                       |
+| Files expected to change                       | ✅     | ✅                       |
+| Fix approach (and alternatives considered)     | ✅     | ✅                       |
+| Risk rating (low/medium/high)                  | ✅     | ✅                       |
+| Reproduction steps                             | ✅     | ✅ (must be executable)  |
+| Manual testing strategy                        | ✅     | ✅ expanded              |
+| Rollback plan                                  |        | ✅                       |
+| Blast radius (rendered output / deploy / URLs) |        | ✅                       |
+
+Risk ≥ medium if **any** of:
+
+- the bump touches the build pipeline (`astro`, `vite`, `@astrojs/*`, MDX/rehype/remark plugins, `pagefind`)
+- the fix edits anything under `src/` rather than config or lockfile
+- the bump can change emitted HTML, CSS ordering, font loading, or hydration behaviour
+- a `github-actions` change touches `deploy.yml` (a broken deploy is a live-site outage, not a red check)
+
+Any npm **major** is at least medium by default. A major arrives alone precisely because it warrants reading and testing by itself; treat it with more scrutiny than a batch of the same size.
+
+### Step 8 · Manual testing strategy (tiered)
+
+Tier the effort by Step 7's risk rating:
+
+- **Low (tooling only)** — apply fix, run the narrowest relevant gate (`npm run lint`, `npm run format:check`, or `npm run check:ratchet`). No reproduction step needed.
+- **Medium (build pipeline or `src/` edit)** — first **reproduce** the failure locally on the PR branch to prove the regression is real (not a CI artefact). Then apply the fix, re-run the full local definition of done: `npm run lint && npm run format:check && npm run check:ratchet && npm run build`. Then Phase E.
+- **High (majors, anything that can change rendered output, deploy changes)** — everything in medium, plus Phase E's parity sweep is **mandatory**, plus `npm run verify:dom:all` against the built PR head, plus `npm run verify:typewriter` if the hero or motion tokens are implicated.
+
+Keep all scratch output under `./tmp/` (gitignored). Use `./tmp/null` as the sink when suppressing output:
+
+```bash
+npm run build 2>./tmp/null
+```
+
+---
+
+## Phase E — Visual parity against the merge base
+
+CI proves the site still builds. It does not prove the site still looks the same. A dependency bump should be **pixel-neutral by definition** — if it is not, something rendered differently and nobody would have seen it. This phase is the reason this skill exists on this repo.
+
+No pixel baselines are committed (`scripts/verify/out/` and `tmp/` are gitignored), so the comparison has to be generated in-run: capture the merge base, capture the PR head, compare.
+
+### Step 8.5 · Decide whether to run it
+
+The sweep costs roughly **4–5 minutes** per PR (two builds plus two screenshot sweeps over 37 routes × 2 viewports). Skip it only when the change **cannot** affect rendering. It is skippable when **all** of these hold:
+
+- The PR is `github-actions` only, or touches only `.github/**`
+- No file under `src/`, `public/`, `astro.config.mjs`, or `package.json` `dependencies` changed
+- The diff is confined to devDependencies whose output never reaches `dist/` (`eslint*`, `prettier`, `@types/*`, `typescript` when the ratchet is unchanged)
+
+Anything else — any `astro`, `vite`, `@astrojs/*`, `preact`, `pagefind`, MDX/rehype/remark, font, or CSS-tooling bump, and every npm major — **runs the sweep**. When in doubt, run it; five minutes is cheaper than a silent visual regression on a live site.
+
+Say explicitly in the report which branch of this decision was taken and why.
+
+### Step 9 · Capture and compare
+
+Playwright is **not** a repo dependency; the harness drives it from an npx cache path already wired into the scripts. Serve each build with a plain static server.
+
+```bash
+BASE_SHA=$(git merge-base origin/master HEAD)
+mkdir -p ./tmp/parity
+
+# --- merge base ---
+git checkout $BASE_SHA
+npm ci
+npm run build
+cp dist/index.html ./tmp/parity/base-index.html    # fingerprint of what we are serving
+nohup npx --yes http-server dist -p 4126 --silent < ./tmp/null > ./tmp/parity/base-server.log 2>&1 &
+BASE_SERVER=$!
+npm run verify:shots:all
+kill $BASE_SERVER
+cp -R scripts/verify/out ./tmp/parity/base
+
+# --- PR head ---
+gh pr checkout $PR_NUM --repo $REPO
+npm ci
+npm run build
+cp dist/index.html ./tmp/parity/head-index.html
+nohup npx --yes http-server dist -p 4126 --silent < ./tmp/null > ./tmp/parity/head-server.log 2>&1 &
+HEAD_SERVER=$!
+npm run verify:shots:all
+kill $HEAD_SERVER
+cp -R scripts/verify/out ./tmp/parity/head
+
+# --- compare, per viewport ---
+npm run verify:parity -- ./tmp/parity/base/1440 ./tmp/parity/head/1440 > ./tmp/parity/1440.json
+npm run verify:parity -- ./tmp/parity/base/420  ./tmp/parity/head/420  > ./tmp/parity/420.json
+```
+
+**The stale-`dist` trap.** Reusing port 4126 across two builds is the single most likely way to produce a confident, meaningless green: if the old server did not actually die, or `dist` was not rebuilt, the second sweep photographs the first build and parity passes because you compared a build to itself. Guard it every run:
+
+- Confirm the previous server is gone before starting the next one (`lsof -i :4126` returns nothing).
+- Diff the two fingerprints — `cmp ./tmp/parity/base-index.html ./tmp/parity/head-index.html` returning "identical" for a PR that changed `src/` or a build-pipeline dep is a signal to distrust the run, not a result.
+- If the sweep's own JSON reports `compared: 0` or every route missing, the server was not up; the run is void, not passing.
+
+`verify:shots` writes dark-theme output to `out/<width>/`. If a bump plausibly affects the light theme differently (CSS tooling, colour handling, token emission), repeat the sweep with `--theme light`, which writes to `out/light/<width>/` and cannot overwrite the dark tree.
+
+### Step 10 · Interpret the result
+
+`verify-parity` reports two numbers per route, and **both matter**:
+
+- `differingPixels` — the AE count. Locates the change. A large count over a flat area can be sub-perceptual.
+- `maxChannelDelta` — the peak single-channel difference out of 255. Sizes the change. This is the number that says whether a human could see it.
+
+| Result                                              | Reading                                                                                                                                        | Action                                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `passed: true`, zero differing pixels               | The bump is pixel-neutral. Expected outcome.                                                                                                    | Proceed. Record "parity clean, 37 routes × 2 viewports" in the report.                                        |
+| Non-zero pixels, `maxChannelDelta` ≤ 2              | Sub-perceptual — usually a rounding or compositing shift from a CSS/build-tool bump.                                                             | Not automatically a failure, but **not yours to wave through**. Report it with route names and the diff images. |
+| Non-zero pixels, `maxChannelDelta` > 2              | A visible rendering change from a dependency bump. Something moved, recoloured, or reflowed.                                                     | **Escalate.** Do not merge, do not allowlist.                                                                  |
+| `size-mismatch` on any route                        | Page height or width changed — a layout regression, the most serious class here.                                                                 | **Escalate.** Always.                                                                                          |
+| Differences confined to canvas-backed routes        | Canvases are masked by `verify:shots`, so this should not happen; if it does, the mask or the canvas mount changed.                              | **Escalate.** Investigate before assuming instability.                                                         |
+| `compared: 0`, routes missing, or fingerprints equal when they should not be | The harness did not measure what you think it measured.                                                             | Void the run and redo it. Never report a void run as green.                                                    |
+
+**Do not use `--allow` or `--tolerance` to make a dependency bump pass.** The allowlist is a reviewed, human-signed mechanism with an `approvedBy` and `approvedIn` field; a bot filing its own entries defeats the gate entirely. A tolerance is for documented canvas instability that reproduces between two captures of the *same* build, which is not this.
+
+**Escalation means: leave the PR open, post the parity JSON and the diff image paths as part of the report comment, state plainly that a human must look at the rendering, and emit `left-open` as the RESULT.** Do not decide alone that a visible pixel change is acceptable — the whole point is that this is exactly the class of regression no automated gate in this repo catches.
+
+---
+
+## Phase F — Finalise
+
+### Step 11 · Ship directly on the Dependabot PR
+
+Keep it simple: commit fixes **on the existing Dependabot PR branch**. No replacement PR, no cherry-picking.
+
+```bash
+gh pr checkout $PR_NUM --repo $REPO
+
+# ...make edits...
+git add -A
+git commit   # comprehensive message, see below
+git push
+```
+
+Commit messages in this repo are **comprehensive prose**: a subject line that says what changed, then paragraphs explaining the root cause, the fix and how it was verified. **No trailers, no co-author lines, no session URLs** — that convention is explicit in `AGENTS.md` and applies to PR bodies too.
+
+Monitor CI; rerun known flakes once before investigating:
+
+```bash
+gh pr checks $PR_NUM --repo $REPO
+gh run rerun <run-id> --failed --repo $REPO  # only for a genuine flake
+```
+
+**Caveats:**
+
+- Do not use `@dependabot rebase` after pushing fix commits — it will discard them.
+- Prefer version **pinning** over rollback when a transitive `@latest` drift is the cause.
+
+### Step 11.5 · Merge policy — the owner merges
+
+`master` is PR-only with required checks (`lint`, `typecheck`, `build`), and the standing convention in this repo is that **the owner merges his own PRs**. This skill therefore **does not merge**. It pushes the fix, gets CI green, posts the report, and leaves the PR open with a clear recommendation.
+
+| Situation                                  | Action                                                                       |
+| ------------------------------------------ | ---------------------------------------------------------------------------- |
+| Grouped minor/patch batch, CI green, parity clean | Post report recommending merge. **Leave open.**                        |
+| npm major, CI green, parity clean          | Post report noting it is a major and what was tested. **Leave open.**        |
+| Any parity difference at all               | Post report with the diff evidence and an explicit ask for visual review. **Leave open.** |
+| Scope-rejected                             | Post the scope-reject comment. **Leave open.**                               |
+
+Do not use any in-chat prompt as a merge gate — it does not reliably block execution. The gate is simply that the PR stays open and the owner reviews it.
+
+### Step 12 · Report as a PR comment — never commit
+
+Write the report to `./tmp/pr-${PR_NUM}-report.md` (gitignored) covering: PR context, symptoms, root cause, fix plan, testing evidence, **the parity decision and its result**, and the merge recommendation. Then:
+
+```bash
+gh pr comment $PR_NUM --repo $REPO --body-file ./tmp/pr-${PR_NUM}-report.md
+```
+
+Never commit the report. `tmp/` is gitignored precisely so this stays out of the tree.
+
+### Step 12.5 · Emit a machine-readable result line
+
+As the **final line of output**, print exactly one status line so an orchestrator (e.g. `/dependabot-fix-all`) can classify the outcome without parsing prose:
+
+```
+RESULT: <ready|left-open|superseded|blocked> pr=<PR_NUM> reason="<short phrase>"
+```
+
+- `ready` — fix pushed (or none needed), CI green, parity clean, recommended for the owner to merge.
+- `left-open` — CI green but held for human judgement (parity difference, or a major the run is not confident about).
+- `superseded` — scope-rejected; comment posted, config PR opened if applicable, original left open.
+- `blocked` — could not be fixed this run (record why in `reason`).
+
+This skill runs **fully non-interactive / autopilot**: never ask questions in any mode — resolve every decision autonomously per the policies above and emit the RESULT line. "Escalate" here means *leave the PR open and say so in the report*, not *stop and ask*.
+
+### Step 13 · Evaluate skill currency
+
+After the run, ask whether it surfaced a **major, repeatable** learning that future runs would miss without it. Examples:
+
+- A new failure pattern not in the appendix
+- A repo-level invariant that changed (a new required check, a Node bump in `.tool-versions`, a harness script rename)
+- A workflow step that proved redundant in practice
+
+If yes — and only if the learning is non-obvious — propose a small follow-up PR updating this SKILL.md. Resist adding minor details a competent operator would infer; bloat degrades the skill.
+
+---
+
+## Invariants
+
+- Work directly on the Dependabot PR branch; do not open replacement PRs
+- Never `@dependabot rebase` after pushing fix commits (it discards them)
+- Prefer version **pinning** over rollback for toolchain drift
+- A grouped PR failing on one package is fixed or pinned, never abandoned
+- Scratch files under `./tmp/` (never `/tmp/`); suppress output with `2>./tmp/null`
+- Comprehensive commit messages; **no trailers, no co-author lines, no session URLs**
+- The report is **posted as a PR comment**, never committed
+- **This skill never merges.** The owner merges; the skill leaves the PR open with a recommendation
+- Never use `--allow` or `--tolerance` to make a bump pass parity
+- Runs fully non-interactive (autopilot); the **final output line** is the `RESULT:` status line
+
+---
+
+## Appendix · Ecosystem cheat-sheet
+
+Failure modes to expect on this repo. Treat these as hypotheses, not diagnoses — Phase C must still verify.
+
+### `npm` (root — the only npm directory)
+
+- **Lockfile desync** is the dominant failure mode on grouped PRs: every job fails at `npm ci` with `Missing: <pkg> from lock file`. Fix: delete **both** `node_modules` **and** `package-lock.json`, then `npm install`. Deleting only `node_modules` can leave an optional-native-binding error from a bundler's platform packages.
+- `prettier` bumps reformat files and break `format:check` even though nothing else changed. Fix is to run `npm run format` and commit the churn — but check the diff, because a formatter that reflows `src/**` at a new print width is a real change, not noise. Astro/MDX use ~160 columns, TS/scripts ~100.
+- `eslint` and plugin bumps drift the flat config; new rules fire on existing code. Prefer fixing the code; disable a rule only with a written reason.
+- `astro` / `@astrojs/*` bumps are the highest-risk class: they can change emitted HTML, CSS ordering, script hydration, and view-transition behaviour without failing the build. **Always run Phase E**, and add `npm run verify:dom:all`.
+- `typescript` bumps can move the `astro check` count off the baseline in `scripts/verify/astro-check-baseline.json`. The ratchet is meant to hold at zero — fix the errors rather than re-baselining, and never raise the baseline to make a bump pass.
+- Style-adjacent bumps can trip `verify-styles-doc.mjs`'s `styles-hash` in `check:ratchet`. If a bump genuinely changed emitted style blocks, that is a Phase E signal, not a re-bless-and-move-on.
+- `pagefind` runs as `postbuild`; a bump failing there breaks search on the deployed site while the build still looks fine locally if you skip `postbuild`.
+- `preact` bumps affect only the islands (survey tabs, sorting). Cheap to verify, but they are the parts of the site with real state.
+- Local reproduction, in order: `npm ci && npm run lint && npm run format:check && npm run check:ratchet && npm run build`.
+- Playwright is **not** a repo dependency — the harness imports it from `/Users/asaucedo/.npm/_npx/e41f203b7505f1fb/node_modules/playwright/index.js`. A Playwright-related failure is therefore never a Dependabot problem in this repo.
+
+### `github-actions`
+
+- Grouped and usually trivial. Almost always Phase E-skippable (see Step 8.5) — these bumps cannot change a pixel.
+- `actions/setup-node` majors: check alignment with `.tool-versions` (`nodejs 22.14.0`), which both CI and deploy read via `node-version-file`.
+- `actions/checkout` and `actions/upload-pages-artifact` / `deploy-pages` majors touch the **deploy** path. A broken deploy is a live-site outage that no PR check catches, because `deploy.yml` only runs on push to `master`. Read the changelog for these specifically, and say in the report that the deploy path changed.
+- The production build injects `FORM_ENDPOINT` from a secret in `deploy.yml` and deliberately does not in CI. An actions bump that changes how env or secrets are passed can silently ship the contact form in demo mode.
+- Cache-action majors can change cache keys, which manifests as slow-but-green CI, not a failure.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
 
-# Routine version updates arrive in one batch on Wednesday mornings rather than
-# as a trickle of single-package pull requests. Security updates are a separate
-# GitHub feature and are NOT governed by this schedule: they open as soon as an
-# advisory lands, which is the behaviour we want. The grouping below applies to
-# both, so a security batch also arrives as one pull request per group.
+# One batch, not a trickle. Routine version updates arrive as a single pull
+# request per ecosystem on Wednesday mornings; security updates arrive as a
+# single pull request as soon as an advisory lands.
+#
+# `applies-to` is load-bearing. A group without it covers version updates ONLY,
+# so security updates fall back to one pull request per advisory no matter how
+# the version groups are arranged. That is why every ecosystem below declares
+# both an `all` and an `all-security` group.
+#
+# Majors stay on their own for npm: a framework bump usually needs reading and
+# testing by itself, and bundling one into a batch means the whole batch fails
+# or the major goes in unread.
 updates:
   - package-ecosystem: npm
     directory: /
@@ -15,30 +22,15 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
     groups:
-      # Astro and its integrations move together; a split upgrade usually fails
-      # to build, so they belong in one pull request.
-      astro:
-        patterns:
-          - astro
-          - '@astrojs/*'
-      # Lint, format and type tooling: churny, low risk, and never worth a
-      # pull request each.
-      tooling:
-        patterns:
-          - eslint
-          - eslint-*
-          - '@eslint/*'
-          - '@typescript-eslint/*'
-          - prettier
-          - prettier-*
-          - typescript
-          - globals
-      # Everything else that is not a major bump. Majors stay individual so
-      # they can be read and tested on their own.
-      minor-and-patch:
+      all:
+        applies-to: version-updates
+        patterns: ['*']
         update-types:
           - minor
           - patch
+      all-security:
+        applies-to: security-updates
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: /
@@ -48,6 +40,9 @@ updates:
       time: '06:00'
       timezone: Europe/Berlin
     groups:
-      actions:
-        patterns:
-          - '*'
+      all:
+        applies-to: version-updates
+        patterns: ['*']
+      all-security:
+        applies-to: security-updates
+        patterns: ['*']

--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,12 @@ _site/
 # Working / scratch files
 tmp/
 
-.claude
+# Agent-local state stays out of the repo, but skills are project tooling and
+# belong to everyone working on it. The eslint ignore for .claude is separate
+# (eslint.config.mjs) and unaffected: worktrees are still never linted.
+.claude/*
+!.claude/skills/
+.claude/settings.local.json
 CLAUDE.md
 tmp2
 .obsidian/


### PR DESCRIPTION
Adopted from the `kaos` repo: the grouped Dependabot config, and the two skills that work through the PRs it opens.

## The config

**One pull request per ecosystem, not four.** npm updates were split across `astro`, `tooling` and `minor-and-patch` groups — still a trickle, and what produced #29–#33. They collapse into a single `all` group.

**It also fixes a real defect.** `applies-to` defaults to `version-updates`, so the previous groups never covered security updates, despite a comment in the file claiming they did:

> The grouping below applies to both, so a security batch also arrives as one pull request per group.

Security advisories were opening one PR each — the behaviour the grouping was meant to prevent, and the case where it matters most, since they arrive unscheduled. Every ecosystem now declares an explicit `all-security` group alongside `all`, as `kaos` does.

npm majors stay individual: a framework bump wants reading and testing on its own.

## The skills

`dependabot-fix` diagnoses and fixes one PR; `dependabot-fix-all` orchestrates it across every open one. Adapted rather than written fresh, so the phase discipline, risk tiers, scope triage and invariants come from something already used in anger.

Repo-specific changes: ecosystems reduced to npm and github-actions, with a cheat-sheet covering what actually breaks here — lockfile desync, prettier and eslint churn, the `astro check` baseline, the `-a###` ratchet, `styles-hash` drift, the `pagefind` postbuild, and `deploy.yml` bumps as a live-site risk no PR check covers. Child sessions run through Codex rather than Copilot. **Nothing auto-merges**, since the owner merges his own PRs.

### Visual parity — the substantive addition

The source has no equivalent, and this repo has the machinery but never runs it in CI. No pixel baselines are committed, so the skill generates its own comparison:

1. Build the merge base → capture
2. Build the head → capture
3. Compare — **expect zero differing pixels**

A dependency bump should be pixel-neutral by definition, and one that moves the rendering is exactly the failure `lint`, `typecheck` and `build` cannot see. Skippable where rendering cannot be affected (an actions-only bump), and it may never be waved through with `--tolerance` or `--allow`.

## Gitignore

Skills are project tooling rather than agent-local state, so `.gitignore` now tracks `.claude/skills` while still excluding `worktrees` and local settings. The eslint ignore for `.claude` is separate and unaffected, so agent worktrees are still never linted.

Does not touch #29–#33, which were opened under the old config.