### PR TITLE
Pin nanoid past the infinite-loop advisory with an override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,9 +6848,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "prettier-plugin-astro": "0.14.1",
     "typescript": "6.0.3",
     "typescript-eslint": "8.66.0"
+  },
+  "overrides": {
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
Clears Dependabot alert 4 (nanoid, high), which Dependabot reports it cannot fix on its own.

## Why Dependabot is stuck and why it does not have to be

It reports that reaching a patched nanoid would drag `@astrojs/mdx` from 7.0.3 back to 0.19.7, and so leaves the tree on 3.3.16. That conflict is an artefact of how it searches for a resolution, not a real constraint. `postcss` is the only package in this tree that depends on nanoid, and it asks for `^3.3.16`, which both 3.3.17 and 3.3.18 satisfy.

Declaring the floor directly resolves cleanly. The regenerated lockfile confirms it:

| | before | after |
| --- | --- | --- |
| `nanoid` | 3.3.16 | **3.3.18** |
| `@astrojs/mdx` | 7.0.5 | 7.0.5 (unchanged) |

The whole diff is three lines of `package.json` and nanoid's version, resolved and integrity in the lockfile.

## What the advisory is worth here

It needs an application to hand `customAlphabet` or `customRandom` an attacker-controlled `size` of zero, which then spins forever. Nothing on this site does that, and nanoid never reaches the browser: none of the 44 bundles under `dist/_astro` reference `nanoid` or `customAlphabet`, because it arrives only through postcss, astro and eslint at build time.

So this is housekeeping rather than a security fix. The reason to do it is that a standing high-severity alert nobody can action is one people learn to skim past, and that habit is the actual cost.

## Why an override rather than waiting

It states the floor we require and keeps stating it as the tree moves, so a future transitive bump cannot quietly reintroduce a vulnerable nanoid. It can be dropped once postcss raises its own floor past the patched version.

## Verification

The local build passes, but that is weak evidence here: this worktree's `node_modules` is symlinked to the previous install, so it still exercises 3.3.16. CI installs from the regenerated lockfile, so its build, typecheck, lint, motion and visual jobs are the real check that 3.3.18 changes nothing.
