### PR TITLE
docs(agents): require worktrees, explicit staging and conventional commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,22 @@ All changes land on `master` through a pull request; direct pushes are blocked b
 
 1. Branch from `master` **in your own git worktree** (`git worktree add ./tmp/wt-<slug> -b <branch> origin/master`), so parallel tracks never share a dirty checkout. This is not optional housekeeping: other sessions and background agents are routinely live in the main checkout, and working there means their uncommitted files are in your `git status`.
 2. **Stage explicit paths, never a directory**, and read `git diff --cached --name-only` before you commit. `git add <dir>` sweeps up whatever a concurrent session happens to have untracked in that directory. That is not merely noise in the diff: committing another session's untracked file makes it tracked, so the next branch switch **deletes it from their working tree**. A file you did not touch appearing in your diff means stop and find out whose it is.
-3. Commit with comprehensive messages. Do not append session URLs to commit messages or PR bodies.
+3. Commit with comprehensive messages in [Conventional Commits](https://www.conventionalcommits.org) form: `type(scope): summary`, imperative mood, no trailing full stop. PR titles take the same form. Do not append session URLs to commit messages or PR bodies.
+
+   | Type       | For                                                 |
+   | ---------- | --------------------------------------------------- |
+   | `feat`     | A capability the site did not have                  |
+   | `fix`      | A defect in shipped behaviour                       |
+   | `refactor` | Structure changes with no change in rendered output |
+   | `perf`     | A measured improvement to speed or payload          |
+   | `docs`     | `AGENTS.md`, `STYLES.md`, `README.md`, skills       |
+   | `test`     | The `scripts/verify/` harness and its gates         |
+   | `build`    | Dependencies, the Astro config, the lockfile        |
+   | `ci`       | `.github/workflows/`                                |
+   | `chore`    | Anything that fits none of the above                |
+
+   The scope is the surface, not the file: `feat(newsletter)`, `fix(header)`, `refactor(tokens)`, `ci(visual)`. Omit it when a change is genuinely site-wide. The subject line is the summary; the body still carries the reasoning, and a comprehensive body matters more than the prefix. Mark a breaking change with `!` after the type or scope.
+
 4. Push the branch and open a PR with `gh pr create`, then check `gh pr diff <n> --name-only` and confirm every file belongs to the change.
 5. CI (`.github/workflows/ci.yml`) runs four required checks — `lint` (ESLint and Prettier), `typecheck` (the `astro check` ratchet), `build` (the production build, in demo mode without `FORM_ENDPOINT`) and `motion` (the view-transition settle gate) — plus `visual`, a merge-base pixel-parity sweep whose enforcement depends on the PR's labels.
 6. Merge once CI is green. The merge landing on `master` triggers the production deploy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,12 @@ The website for The Institute for Ethical AI Alignment & Safety (`ethical.instit
 
 All changes land on `master` through a pull request; direct pushes are blocked by a branch ruleset.
 
-1. Branch from `master` (agents work in their own git worktree so parallel tracks never share a dirty checkout).
-2. Commit with comprehensive messages. Do not append session URLs to commit messages or PR bodies.
-3. Push the branch and open a PR with `gh pr create`.
-4. CI (`.github/workflows/ci.yml`) runs four required checks — `lint` (ESLint and Prettier), `typecheck` (the `astro check` ratchet), `build` (the production build, in demo mode without `FORM_ENDPOINT`) and `motion` (the view-transition settle gate) — plus `visual`, a merge-base pixel-parity sweep whose enforcement depends on the PR's labels.
-5. Merge once CI is green. The merge landing on `master` triggers the production deploy.
+1. Branch from `master` **in your own git worktree** (`git worktree add ./tmp/wt-<slug> -b <branch> origin/master`), so parallel tracks never share a dirty checkout. This is not optional housekeeping: other sessions and background agents are routinely live in the main checkout, and working there means their uncommitted files are in your `git status`.
+2. **Stage explicit paths, never a directory**, and read `git diff --cached --name-only` before you commit. `git add <dir>` sweeps up whatever a concurrent session happens to have untracked in that directory. That is not merely noise in the diff: committing another session's untracked file makes it tracked, so the next branch switch **deletes it from their working tree**. A file you did not touch appearing in your diff means stop and find out whose it is.
+3. Commit with comprehensive messages. Do not append session URLs to commit messages or PR bodies.
+4. Push the branch and open a PR with `gh pr create`, then check `gh pr diff <n> --name-only` and confirm every file belongs to the change.
+5. CI (`.github/workflows/ci.yml`) runs four required checks — `lint` (ESLint and Prettier), `typecheck` (the `astro check` ratchet), `build` (the production build, in demo mode without `FORM_ENDPOINT`) and `motion` (the view-transition settle gate) — plus `visual`, a merge-base pixel-parity sweep whose enforcement depends on the PR's labels.
+6. Merge once CI is green. The merge landing on `master` triggers the production deploy.
 
 The `visual` job builds and photographs both the merge base and the head, so there are no committed baselines to go stale. It skips entirely when nothing under `src/`, `public/` or `package-lock.json` changed, and otherwise:
 


### PR DESCRIPTION
The change workflow already told agents to branch in their own worktree — but in parentheses, as though it were housekeeping, and it said nothing about how to stage. Both gaps were exercised today.

Work happened directly in the main checkout while other sessions and background agents were live in it. Then a `git add .claude/skills` — a directory, not the files actually edited — swept another session's untracked newsletter skill into #49.

**The second failure mode is worth spelling out, because the damage is not obvious.** Committing someone else's untracked file makes it *tracked*, so the next branch switch **deletes it from their working tree**. A stray file in a diff is not noise to tidy up later; it can take live work away from a concurrent session. That is what happened, and the files had to be recovered from the commit that removed them.

Changes:

- The worktree rule comes out of parentheses and carries the command to run
- New step: stage explicit paths, never a directory, and read `git diff --cached --name-only` before committing
- Opening a PR now includes checking `gh pr diff <n> --name-only` and confirming every file belongs
- Steps renumbered