### PR TITLE
ci(workflows): run each job only when its inputs changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,62 @@ env:
   PLAYWRIGHT_VERSION: 1.62.1
 
 jobs:
+  # One cheap job decides what the rest are for, so a documentation change does
+  # not build the site four times. The classification is deliberately generous:
+  # a wrongly included path costs a few runner minutes, a wrongly excluded one
+  # lets a real regression through, so anything ambiguous belongs in both lists.
+  # `.github/workflows` is in both, since a change to the gates has to be run by
+  # the gates. The visual job keeps its own narrower scope check on top of this.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      lint: ${{ steps.filter.outputs.lint }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Classify the change against the merge base
+        id: filter
+        # Explicit because the pathspec lists are deliberately word-split when
+        # unquoted, which bash does and some shells do not.
+        shell: bash
+        env:
+          # What a build, the ratchet, the motion gate and the sweep read.
+          CODE_PATHS: src public scripts package.json package-lock.json astro.config.mjs tsconfig.json .tool-versions STYLES.md .github/workflows
+          # What `npm run lint` and `npm run format:check` actually cover.
+          LINT_PATHS: src scripts astro.config.mjs eslint.config.mjs prettier.config.mjs package.json package-lock.json tsconfig.json AGENTS.md README.md .github/workflows
+        run: |
+          # Anything that is not a pull request has no merge base to diff, so it
+          # runs everything rather than guessing.
+          if [ "${{ github.event_name }}" != 'pull_request' ]; then
+            echo 'Not a pull request; running every job.'
+            echo 'code=true' >> "$GITHUB_OUTPUT"
+            echo 'lint=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags --prune origin "$GITHUB_BASE_REF"
+          base=$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)
+          echo "Merge base: $base"
+          git diff --name-only "$base" HEAD | sed 's/^/  /'
+          for group in code lint; do
+            case "$group" in
+              code) paths="$CODE_PATHS" ;;
+              lint) paths="$LINT_PATHS" ;;
+            esac
+            # shellcheck disable=SC2086
+            if [ -n "$(git diff --name-only "$base" HEAD -- $paths)" ]; then
+              echo "$group=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$group=false" >> "$GITHUB_OUTPUT"
+              echo "Nothing under the $group paths changed; skipping those jobs."
+            fi
+          done
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.lint == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -29,6 +84,8 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -39,6 +96,8 @@ jobs:
       - run: npm ci
       - run: npm run check:ratchet
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -57,6 +116,8 @@ jobs:
   # This gate drives real client-side navigations and asserts the arrival is a
   # single motion. It is required, and it is cheap enough to stay that way.
   motion:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -86,9 +147,11 @@ jobs:
   # cannot be blessed by hand. What it does with the answer depends on the
   # labels; see PARITY_MODE below.
   visual:
+    needs: changes
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request' &&
+      needs.changes.outputs.code == 'true' &&
       !contains(github.event.pull_request.labels.*.name, 'visual-change')
     permissions:
       contents: read


### PR DESCRIPTION
Every job ran on every pull request, so a change to `TODO.md` built the site four times and photographed it twice: roughly fifteen runner minutes, and an eight minute wait to prove a markdown file had not moved a pixel.

A first `changes` job resolves the merge base and classifies the change; the rest declare which classification they need. The `visual` sweep already did this internally, but only after a runner had started and a repository had been checked out. It keeps that narrower check, scoped to what it actually photographs, and gains the cheaper outer one.

## The two lists

Drawn from what the jobs read, not from intuition.

| List | Contents | Why |
| --- | --- | --- |
| `lint` | `src`, `scripts`, the root configs, `package.json`, `tsconfig.json`, `AGENTS.md`, `README.md` | Exactly what `npm run lint` and `npm run format:check` cover, which is why the two markdown files are on it |
| `code` | the above plus `public`, `package-lock.json`, `.tool-versions`, `STYLES.md` | What a build, the ratchet, the motion gate and the sweep read. `STYLES.md` is there because the ratchet fails when it drifts from the stylesheets |

Both carry `.github/workflows`, since a change to the gates has to be run by the gates. Anything that is not a pull request has no merge base to diff and runs everything rather than guessing.

The bias is deliberate: a wrongly included path costs runner minutes, a wrongly excluded one lets a regression through, so anything ambiguous is on both lists.

## Verified before pushing

The classification was run against real diffs rather than reasoned about:

| Change | code | lint |
| --- | --- | --- |
| `TODO.md` only (#54) | false | false |
| the 28-file surface-role change (#51) | true | true |
| `README.md` only | false | true |
| this pull request | true | true |

This PR touches `.github/workflows`, so it runs every job, which is the intended behaviour and also the only way to see the new `changes` job execute. The skip path gets its first real exercise on the next documentation-only pull request; #54 is open and will show it once rebased.

## Note on required checks

`master` is not a protected branch, so no status is required to merge and a skipped job cannot strand a pull request. If protection is added later, the skipped jobs would need to be either not required or replaced with the always-run short-circuit pattern.