### PR TITLE
test(canvas): prove every mount paints for its real backdrop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,11 @@ jobs:
           echo "the built site never came up on :4126" >&2
           exit 1
       - run: npm run verify:motion:all
+      # Canvas paints outside the cascade, so its colours come from the surface a
+      # mount sits on rather than the active theme. The screenshot gate masks every
+      # canvas and only runs dark, where both surfaces resolve identically — so this
+      # is the only check that can see a mount painting for the wrong backdrop.
+      - run: npm run verify:canvas-surface
 
   # Pixel parity against the PR's merge base. No baselines are committed — the
   # job builds and photographs both sides itself, so it cannot go stale and

--- a/STYLES.md
+++ b/STYLES.md
@@ -64,9 +64,21 @@ noticing that their alphas were never jobs in the first place:
   mark. The nine light values turned out to be nothing but their dark alpha times 1.32, so that
   factor is now `--ink-wash-lift` rather than nine hand-tuned numbers. Zero pixels in dark; light
   lands within 0.7/255 of the values it replaced.
-- **Shadows.** The one family where alpha _is_ cheap: black on near-black moves `Δα × 19`, so the
-  three deep steps (.60/.55/.50) were one job at three hand-typed strengths and merge inside the
-  budget. Two rungs now: `--shadow-drop` for a raised panel or overlay, `--shadow-lift` for a tile.
+- **Shadows.** The three deep steps (.60/.55/.50) were one job at three hand-typed strengths and
+  became `--shadow-drop`; `--shadow-lift` is the tile shadow. Two rungs now.
+
+  **The budget argument for that merge was wrong, and the merge was kept anyway — knowingly.** It
+  read `Δα × 19`, black over `--bg-base`, giving 1.9/255 for .50 → .60. But these shadows fall
+  under dropdowns and modals, on a scrimmed overlay rather than the raw page, and measured on real
+  captures of the command palette the change is **45/255 across ~337k pixels**. Far outside the
+  3/255 budget. It survives because the owner compared the two side by side and could not see any
+  difference — 45/255 spread through a soft gradient reads as nothing — not because it was small.
+
+  **Nothing measured it at the time, and nothing would today.** No screenshot in `routes.json`
+  opens a menu or a modal, so the entire shadow family is unpainted in every capture. `verify:parity`
+  reported `0/255` for shadows throughout, which meant "no capture paints them", not "safe". If you
+  change a shadow, compare it by hand with the palette or a mega menu open; the sweep will agree
+  with you whatever you do.
 
 **Do not propose collapsing the rest invisibly.** Ink sits 244 channel levels above the darkest
 surface, so `Δα 0.01` is already `2.44/255` before rendering and ~`3/255` after glyph antialiasing,

--- a/STYLES.md
+++ b/STYLES.md
@@ -143,6 +143,14 @@ to anyone working in the default theme. `npm run check:ratchet` now fails if a l
 selects blocks by class instead of by the role, if `data-surface-plate` appears without it, or if a
 `data-surface` value is anything but `dark` or `page`.
 
+Those are spelling checks: they prove the attribute is used consistently, not that any mount
+resolves to the surface it is really sitting on. `npm run verify:canvas-surface` proves that —
+it loads every route in **light**, walks up from each canvas to the first opaque background, and
+fails if the resolved surface disagrees with what is painted there. Light is the only theme
+where the question has an answer: under dark the page ground _is_ the inverted colour, so a
+mount on the wrong surface looks correct either way. It runs in CI beside the motion gate,
+because it needs a browser and a build.
+
 Canvas paints outside the cascade, so a canvas cannot inherit those re-entered rungs. It therefore
 takes its colours from the **surface it sits on, not from the active theme**, via two token sets on
 `:root`: `--canvas-*` for artwork on the page ground and `--canvas-dark-*` for artwork inside one of

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "verify:typewriter": "node scripts/verify/verify-typewriter.mjs",
     "postbuild": "pagefind --site dist",
     "styles:sync": "node scripts/verify/verify-styles-doc.mjs --sync",
-    "check:styles-doc": "node scripts/verify/verify-styles-doc.mjs"
+    "check:styles-doc": "node scripts/verify/verify-styles-doc.mjs",
+    "verify:canvas-surface": "node scripts/verify/verify-canvas-surface.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "7.2.2",

--- a/scripts/verify/verify-canvas-surface.mjs
+++ b/scripts/verify/verify-canvas-surface.mjs
@@ -15,11 +15,9 @@
 // background, and assert the resolved surface matches what is painted there.
 
 import { readFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import playwright from './playwright.mjs';
 
-const require = createRequire(import.meta.url);
-const PLAYWRIGHT = '/Users/asaucedo/.npm/_npx/e41f203b7505f1fb/node_modules/playwright/index.js';
-const { chromium } = require(process.env.PLAYWRIGHT_PATH ?? PLAYWRIGHT);
+const { chromium } = playwright;
 
 const args = process.argv.slice(2);
 const baseIndex = args.indexOf('--base-url');

--- a/scripts/verify/verify-canvas-surface.mjs
+++ b/scripts/verify/verify-canvas-surface.mjs
@@ -1,0 +1,120 @@
+// Every canvas must paint for the surface it actually sits on.
+//
+//   node scripts/verify/verify-canvas-surface.mjs [--base-url URL]
+//
+// `surfaceOf()` resolves a mount by walking up to the nearest `[data-surface]`.
+// The syntactic checks in verify-check.mjs prove the attribute is spelled right
+// and that the stylesheet keys off it; none of them proves the resolution is
+// TRUE — that the surface a mount resolves to is the surface its backdrop
+// actually is. That is the invariant the whole per-surface palette rests on,
+// and nothing else can see it: the screenshot gate masks every canvas, and it
+// only runs the dark theme, where both surfaces resolve identically and the
+// question is unanswerable by construction.
+//
+// So: load each route in LIGHT, find each canvas, walk up for the first opaque
+// background, and assert the resolved surface matches what is painted there.
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const PLAYWRIGHT = '/Users/asaucedo/.npm/_npx/e41f203b7505f1fb/node_modules/playwright/index.js';
+const { chromium } = require(process.env.PLAYWRIGHT_PATH ?? PLAYWRIGHT);
+
+const args = process.argv.slice(2);
+const baseIndex = args.indexOf('--base-url');
+const baseUrl =
+  (baseIndex >= 0 ? args[baseIndex + 1] : undefined) ??
+  process.env.VERIFY_BASE_URL ??
+  'http://127.0.0.1:4126';
+const routes = JSON.parse(readFileSync(new URL('./routes.json', import.meta.url), 'utf8'));
+
+// Perceptual lightness of the composited backdrop. The two grounds are far
+// apart (#f6f8f6 against #39433f), so the midpoint is not a tuned threshold.
+const DARK_BELOW = 0.45;
+
+const probe = () =>
+  Array.from(document.querySelectorAll('canvas')).map((canvas) => {
+    const host =
+      canvas.closest('kaos-graph, kaos-architecture, kompute-cube, [data-surface]') ??
+      canvas.parentElement;
+    let node = host;
+    let backdrop = 'transparent';
+    while (node && backdrop === 'transparent') {
+      const painted = getComputedStyle(node).backgroundColor;
+      if (painted && painted !== 'rgba(0, 0, 0, 0)') backdrop = painted;
+      node = node.parentElement;
+    }
+    const channels = (backdrop.match(/\d+/g) ?? ['255', '255', '255']).map(Number);
+    const luminance = (channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722) / 255;
+    return {
+      host: host?.tagName?.toLowerCase() ?? 'unknown',
+      resolved: host?.closest('[data-surface]')?.getAttribute('data-surface') ?? 'page',
+      backdrop,
+      luminance,
+    };
+  });
+
+const run = async () => {
+  const browser = await chromium.launch();
+  const failures = [];
+  let checked = 0;
+
+  for (const route of routes) {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+    // Light is the only theme where the question has an answer: under dark the
+    // page ground IS the inverted colour, so every mount looks correct either way.
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('theme', 'light');
+      } catch {
+        /* private mode */
+      }
+    });
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.goto(baseUrl + route, { waitUntil: 'domcontentloaded' });
+    // Scroll-mounted canvases do not exist until they are reached.
+    await page.evaluate(async () => {
+      for (let y = 0; y < document.body.scrollHeight; y += 800) {
+        window.scrollTo(0, y);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    });
+    for (const mount of await page.evaluate(probe)) {
+      checked += 1;
+      const backdropIsDark = mount.luminance < DARK_BELOW;
+      if ((mount.resolved === 'dark') !== backdropIsDark) {
+        failures.push({ route, ...mount });
+      }
+    }
+    await page.close();
+  }
+
+  await browser.close();
+
+  if (!checked) {
+    console.error(
+      'canvas-surface: no canvases found — the probe measured nothing, which is not a pass',
+    );
+    process.exit(1);
+  }
+
+  if (failures.length) {
+    console.error(
+      `canvas-surface: ${failures.length} of ${checked} mounts paint for the wrong surface\n`,
+    );
+    for (const failure of failures) {
+      console.error(
+        `  ${failure.route} ${failure.host}: resolved "${failure.resolved}" but sits on ${failure.backdrop}`,
+      );
+    }
+    console.error(
+      '\nEither the mount needs its own data-surface, or the block it sits in needs the role.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`canvas-surface: ok (${checked} mounts, every one matches its backdrop)`);
+};
+
+await run();


### PR DESCRIPTION
A review of the surface-role change (#51) reported that canvases had silently changed surface in light theme. Answering it required a browser probe by hand, because **no check could answer it**. That is the gap this closes.

The probe found the opposite of the report — **56 mounts, 0 mismatches**, every canvas resolving to the surface its backdrop actually is. The mount the review flagged (`/principles/09/`) sits on `rgb(246, 248, 246)`, the page ground, so resolving to `page` is correct. Forcing it back to `data-surface="dark"` — the state *before* #51 — is what this check fails on, which is the same defect #51 fixed.

So the review's conclusion was wrong, but its point 3 was right: the five existing checks are syntactic. They prove the attribute is spelled consistently and that the stylesheet keys off it. None proves the resolution is **true**.

**Nothing else can see this.** The screenshot gate masks every canvas, and it only runs dark — where the page ground *is* the inverted colour, so a mount on the wrong surface renders correctly either way and the question is unanswerable by construction.

`verify:canvas-surface` loads every route in **light**, walks up from each canvas to the first opaque background, and fails if the resolved surface disagrees with what is painted there. It runs beside the motion gate, since it needs a browser and a build.

Proven both ways:

| | Result |
| --- | --- |
| master | `ok (56 mounts, every one matches its backdrop)` |
| one page-ground mount forced to `dark` | fails, names `/principles/09/` and the backdrop it sits on |

A probe that finds nothing is also treated as a failure — zero canvases means it measured nothing, which is not a pass.