### PR TITLE
ci(visual): photograph light as well as dark

### DIFF
--- a/.github/scripts/capture-shots.sh
+++ b/.github/scripts/capture-shots.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Serves a built site on :4126, photographs every route in routes.json at both
+# Serves a built site on $port, photographs every route in routes.json at both
 # viewports, and moves the captures to $2.
 #
 #   capture-shots.sh <dist-dir> <destination>
@@ -11,7 +11,7 @@
 # captures taken by two different procedures. Only the built output should
 # differ between the two sides.
 #
-# Reusing :4126 across two builds is the one reliable way to produce a
+# Reusing :$port across two builds is the one reliable way to produce a
 # confident, meaningless green: if the first server survives, the second sweep
 # photographs the first build and parity passes because it compared a build to
 # itself. That is not hypothetical — it happened on the first CI run of this
@@ -32,6 +32,8 @@ set -euo pipefail
 
 dist="$1"
 destination="$2"
+theme="${3:-dark}"
+port="${4:-4126}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$root"
 
@@ -40,7 +42,7 @@ test -d "$dist" || {
   exit 1
 }
 
-port_free() { ! curl -fsS -o /dev/null --max-time 2 "http://127.0.0.1:4126/" 2>/dev/null; }
+port_free() { ! curl -fsS -o /dev/null --max-time 2 "http://127.0.0.1:$port/" 2>/dev/null; }
 
 await_port_free() {
   for _ in $(seq 1 20); do
@@ -51,7 +53,7 @@ await_port_free() {
 }
 
 if ! port_free; then
-  echo "something is already serving :4126; refusing to photograph it" >&2
+  echo "something is already serving :$port; refusing to photograph it" >&2
   exit 1
 fi
 
@@ -59,33 +61,33 @@ rm -rf scripts/verify/out
 
 # `setsid` puts the server and every child npx spawns into one process group, so
 # teardown can take the group down rather than only the wrapper.
-setsid npx --yes http-server "$dist" -p 4126 --silent &
+setsid npx --yes http-server "$dist" -p "$port" --silent &
 server=$!
 cleanup() {
   kill -TERM "-$server" 2>/dev/null || kill -TERM "$server" 2>/dev/null || true
   wait "$server" 2>/dev/null || true
   await_port_free || {
-    echo ":4126 is still held after teardown; the next sweep would photograph this build" >&2
+    echo ":$port is still held after teardown; the next sweep would photograph this build" >&2
     exit 1
   }
 }
 trap cleanup EXIT
 
 for _ in $(seq 1 60); do
-  curl -fsS -o /dev/null "http://127.0.0.1:4126/" && break
+  curl -fsS -o /dev/null "http://127.0.0.1:$port/" && break
   sleep 1
 done
 
 # The identity check. If this passes, the sweep is photographing $dist and
 # nothing else — no surviving server, no stale build, no silent green.
-served=$(curl -fsS "http://127.0.0.1:4126/" | shasum | cut -d' ' -f1)
+served=$(curl -fsS "http://127.0.0.1:$port/" | shasum | cut -d' ' -f1)
 ondisk=$(shasum < "$dist/index.html" | cut -d' ' -f1)
 if [ "$served" != "$ondisk" ]; then
-  echo "‽ :4126 is not serving $dist (served $served, on disk $ondisk)" >&2
+  echo "‽ :$port is not serving $dist (served $served, on disk $ondisk)" >&2
   exit 1
 fi
 
-npm run verify:shots:all > /dev/null
+npm run verify:shots:all -- --theme "$theme" > /dev/null
 
 mkdir -p "$(dirname "$destination")"
 rm -rf "$destination"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,15 @@ jobs:
   visual:
     needs: changes
     runs-on: ubuntu-latest
+    # One definition, one leg per theme, run concurrently. Light is where a
+    # theme-only regression can hide: dark is the default everyone develops in,
+    # so a light-only mistake is invisible until someone flips the toggle.
+    # fail-fast is off because a dark failure must not cancel the light leg —
+    # that would withhold the answer the leg exists to give.
+    strategy:
+      fail-fast: false
+      matrix:
+        theme: [dark, light]
     if: >-
       github.event_name == 'pull_request' &&
       needs.changes.outputs.code == 'true' &&
@@ -162,7 +171,13 @@ jobs:
       # Everything else measures and reports without failing.
       PARITY_MODE: >-
         ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') && 'enforce' || 'report' }}
-      COMMENT_MARKER: '<!-- merge-base-visual-parity -->'
+      # Per theme: the comment updater matches on this marker and takes the
+      # last hit, so one marker across two legs means they overwrite each other
+      # and you read one theme's result believing it covers both.
+      COMMENT_MARKER: '<!-- merge-base-visual-parity-${{ matrix.theme }} -->'
+      # Separate ports: both legs can land on one runner, and a held port makes
+      # the second sweep photograph the first build — a silently wrong pass.
+      SHOT_PORT: ${{ matrix.theme == 'light' && '4127' || '4126' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -224,8 +239,8 @@ jobs:
       - name: Capture both builds
         if: steps.scope.outputs.run == 'true'
         run: |
-          .github/scripts/capture-shots.sh "$RUNNER_TEMP/dist-base" "$RUNNER_TEMP/shots/base"
-          .github/scripts/capture-shots.sh "$RUNNER_TEMP/dist-head" "$RUNNER_TEMP/shots/head"
+          .github/scripts/capture-shots.sh "$RUNNER_TEMP/dist-base" "$RUNNER_TEMP/shots/base" "${{ matrix.theme }}" "$SHOT_PORT"
+          .github/scripts/capture-shots.sh "$RUNNER_TEMP/dist-head" "$RUNNER_TEMP/shots/head" "${{ matrix.theme }}" "$SHOT_PORT"
       - name: Compare
         if: steps.scope.outputs.run == 'true'
         id: compare
@@ -246,6 +261,7 @@ jobs:
           node scripts/verify/parity-summary.mjs \
             --mode "$PARITY_MODE" \
             --marker "$COMMENT_MARKER" \
+            --title "Visual parity — ${{ matrix.theme == 'light' && 'light theme ☀️' || 'dark theme 🌙' }}" \
             --out "$RUNNER_TEMP/parity/comment.md" \
             --verdict "$RUNNER_TEMP/parity/verdict.txt" \
             "1440x1000=$RUNNER_TEMP/parity/report-1440.json" \


### PR DESCRIPTION
The parity sweep only ever ran dark. Dark is the default everyone develops in, so a light-only regression in ordinary CSS passes every gate today and is seen first by whoever flips the toggle.

**A matrix, not a second sweep.** Two legs on two runners finish in roughly the wall-clock the single job takes now. Each builds both sides itself — that costs runner minutes rather than your waiting time, and this repository is public, so those are free.

`fail-fast: false` because a dark failure must not cancel the light leg; that withholds exactly the answer the leg was added to give.

**Three things the split needs to be honest:**

| | Why |
| --- | --- |
| Marker carries the theme | The updater matches on the marker and takes the *last* hit. One marker across two legs means they overwrite each other and you read one theme's result believing it covers both. |
| Legs serve on different ports | Both can land on one runner, and a held port makes the second sweep photograph the first build — which passes silently. That failure has appeared three times in this repo. |
| Each comment is titled with its theme | `Visual parity — light theme ☀️` / `— dark theme 🌙`, so the two are told apart on sight rather than by reading a hidden marker. |

`capture-shots.sh` takes the theme and port as optional arguments, defaulting to today's behaviour, so nothing else that calls it changes.

**Verified locally:** `--theme light` yields 37 captures per viewport and they are genuinely light — a sampled pixel reads `srgb(246,248,246)`, the light page ground. The script itself cannot run on macOS (it uses `setsid` for process-group teardown, which is Linux-only), so the end-to-end path is exercised here in CI. This PR touches `.github/**` only, so it will not trigger the visual job itself — the first real exercise is the next code PR.