### PR TITLE
fix(redirects): restore the extension-less /mle/N URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,7 +26,14 @@ const newsletterRedirects = Object.fromEntries(
     // makes the build fail with ENOTDIR. Enable each redirect automatically as
     // its passthrough file is retired.
     .filter((issue) => !existsSync(resolve(`public/mle/${issue}.html`)))
-    .map((issue) => [`/mle/${issue}.html`, `/newsletter/${issue}/`]),
+    // Both spellings. The legacy site served these as real files, so GitHub
+    // Pages resolved an extension-less /mle/395 to mle/395.html for free. A
+    // redirect is a directory, not a file, so that implicit resolution has
+    // nothing to find and every inbound link without the extension 404s.
+    .flatMap((issue) => [
+      [`/mle/${issue}.html`, `/newsletter/${issue}/`],
+      [`/mle/${issue}`, `/newsletter/${issue}/`],
+    ]),
 );
 
 export default defineConfig({
@@ -52,7 +59,9 @@ export default defineConfig({
     '/mle.html': '/newsletter/',
     ...newsletterRedirects,
     '/mle/397.html': '/newsletter/397/',
+    '/mle/397': '/newsletter/397/',
     '/mle/398.html': '/newsletter/398/',
+    '/mle/398': '/newsletter/398/',
     '/privacypolicy.html': '/privacy/',
     '/state-of-ml-2024': '/reports/state-of-ml-2024/',
     '/state-of-ml-2025': '/reports/state-of-ml-2025/',


### PR DESCRIPTION
`https://ethical.institute/mle/395` returns **404**. Every issue is affected — 398 of them — and the links are in search results, in old newsletters and on other people's sites.

**Cause.** The legacy site served these as real files (`mle/395.html`), and GitHub Pages resolves an extension-less request to the `.html` file for free, so both spellings worked. An Astro redirect emits a *directory* (`mle/395.html/index.html`), not a file, so that implicit resolution has nothing to find.

`/mle/395.html` still works — it 301s to `/mle/395.html/` and then serves the redirect. Only the extension-less form broke, which is why it went unnoticed.

**Fix.** Emit both spellings. The config already does exactly this for `/state-of-ml-2024` and its `.html` twin, so this follows the repo's own precedent rather than introducing a pattern.

Verified against a local build of the change:

| URL | Before | After |
| --- | --- | --- |
| `/mle/395` | 404 | 302 → `/newsletter/395/` |
| `/mle/395.html` | 302 | 302 → `/newsletter/395/` |
| `/mle/398` | 404 | 302 → `/newsletter/398/` |
| `/newsletter/395/` | 200 | 200 |

Cost is 398 more redirect stubs (796 total). `dist` is 88M, unchanged to the nearest megabyte — each stub is a few hundred bytes.

One correction to the report: `https://ethical.institute/newsletter/395.html` does **not** work either — it 404s. That spelling never existed; the canonical URL is `/newsletter/395/`, which is fine.