### PR TITLE
feat(header): make search legible and stop the header overflowing

### DIFF
--- a/STYLES.md
+++ b/STYLES.md
@@ -266,7 +266,7 @@ Search by the surface name or representative selector below before adding a rule
 | `RegulationGrid.astro`                                                            | Policy regulation catalogue and themes                                                                 | `.regulation-catalogue`, `.regulation-grid`                                    |
 | `RequestPath.astro`                                                               | KAOS request-path player and scenario controls                                                         | `request-path`, `.scenario-picker`, `.request-stage`                           |
 | `SequencePipeline.astro`                                                          | Kompute sequence pipeline player                                                                       | `sequence-pipeline`, `.pipeline-heading`, `.pipeline-stage`                    |
-| `SiteHeader.astro`                                                                | Persistent header shell, wordmark, desktop navigation triggers, search trigger and right-hand controls | `.site-header`, `.header-row`, `.primary-nav`, `.nav-right`                    |
+| `SiteHeader.astro`                                                                | Persistent header shell, wordmark, desktop navigation triggers, search trigger and right-hand controls | `.site-header`, `.header-row`, `.primary-nav`, `.nav-right`, `.search-trigger` |
 | `MegaMenu.astro`                                                                  | Desktop mega-menu panels, project preview and initiative panes                                         | `.mega-panel`, `.oss-menu`, `.initiative-menu`                                 |
 | `MobileDrawer.astro`                                                              | Mobile navigation drawer, accordion sections and drawer controls                                       | `.mobile-drawer`, `.mobile-nav`, `.mobile-menu-section`                        |
 | `SplitList.astro`                                                                 | Reusable split-list columns                                                                            | `.split-list ul`                                                               |
@@ -339,11 +339,15 @@ Search by the surface name or representative selector below before adding a rule
 
 ## Breakpoints
 
-| Name    |   Width | Use                                                                                               |
-| ------- | ------: | ------------------------------------------------------------------------------------------------- |
-| Wide    | `950px` | Switch desktop navigation, multi-column compositions and full desktop widgets to compact layouts. |
-| Compact | `600px` | Stack dense rows, simplify grids and tighten mobile spacing.                                      |
-| Narrow  | `420px` | Handle the smallest supported viewport where compact rules still need a final adjustment.         |
+| Name         |    Width | Use                                                                                                                                       |
+| ------------ | -------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Header snug  | `1180px` | Compress the header's own controls — row padding and gap, the search keycap, the join label — while the full desktop navigation stays up.  |
+| Nav collapse | `1040px` | Swap the desktop navigation for the drawer. Owned by `SiteHeader`, `MegaMenu` and `MobileDrawer` together; see the note below.             |
+| Wide         |  `950px` | Switch multi-column compositions and full desktop widgets to compact layouts. Layout only — the navigation no longer turns over here.      |
+| Compact      |  `600px` | Stack dense rows, simplify grids and tighten mobile spacing.                                                                               |
+| Narrow       |  `420px` | Handle the smallest supported viewport where compact rules still need a final adjustment.                                                  |
+
+Nav collapse and Wide were the same number until the header row outgrew it. The desktop row has an intrinsic minimum — the wordmark, five menu triggers and the right-hand controls cannot shrink past it — and when that minimum sits above the collapse width, every viewport in between scrolls the page sideways. Nav collapse must therefore stay above the measured row minimum, with enough margin that a font fallback rendering the mono wider cannot close the gap. Move it only against a fresh measurement, and move all four `@media` blocks plus `MobileDrawer`'s `matchMedia` together: a toggle that appears while the drawer is still `display: none` opens nothing.
 
 Use these widths for CSS media queries. A component that needs responsive client behaviour must keep its `matchMedia` condition beside that behaviour and align it with the CSS boundary whenever the states represent the same layout switch.
 
@@ -354,4 +358,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: 58f8efc6ecf7a6f9346a5246f09873c8cd1f222867ec269f0bde3222aa34dea5 -->
+<!-- styles-hash: 1b904480ab7cabf7e4675d6760e26a4ab272fb195f740a03fbeedddd1d799dc4 -->

--- a/src/components/FootnoteBand.astro
+++ b/src/components/FootnoteBand.astro
@@ -56,7 +56,10 @@ const talks = [
     border-top: 1px solid var(--hairline);
     display: grid;
     gap: 44px;
-    grid-template-columns: 1.15fr 0.85fr 250px;
+    /* minmax(0, …) not a bare fr: an fr track's automatic minimum is min-content,
+       so the longest unbreakable link in a column pushes the grid past the page
+       instead of the column shrinking to fit. */
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr) 250px;
     padding: 44px 48px 34px;
   }
 

--- a/src/components/MegaMenu.astro
+++ b/src/components/MegaMenu.astro
@@ -600,7 +600,7 @@ const initialProject = menus.oss.items![0]!;
     line-height: 1.45;
   }
 
-  @media (max-width: 950px) {
+  @media (max-width: 1040px) {
     .mega-panel {
       display: none;
     }

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -132,7 +132,7 @@ import { menus } from '../data/navigation';
         },
         { signal },
       );
-      matchMedia('(min-width: 951px)').addEventListener(
+      matchMedia('(min-width: 1041px)').addEventListener(
         'change',
         (event) => {
           if (event.matches) this.closeMenu();
@@ -195,7 +195,7 @@ import { menus } from '../data/navigation';
     }
   }
 
-  @media (max-width: 950px) {
+  @media (max-width: 1040px) {
     .mobile-drawer {
       background: var(--bg-panel);
       display: block;

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -27,13 +27,30 @@ import MobileDrawer from './MobileDrawer.astro';
         }
       </nav>
       <div class="nav-right">
-        <button class="search-trigger" type="button" data-command-palette-open aria-label="Search the site">
-          <span aria-hidden="true">⌘K</span>
-        </button>
         <button class="nav-trigger" type="button" aria-expanded="false" data-menu-trigger="about" data-menu-width={menus.about.width}>
           {menus.about.label}<span class="caret" aria-hidden="true">▾</span>
         </button>
-        <a class="join-pill" href={join.href}>{join.label}</a>
+        <button class="search-trigger" type="button" data-command-palette-open aria-label="Search the site">
+          <svg
+            class="search-icon"
+            viewBox="0 0 24 24"
+            width="15"
+            height="15"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
+            <circle cx="10.75" cy="10.75" r="6"></circle>
+            <path d="M15.3 15.3 20 20"></path>
+          </svg>
+          <kbd class="search-keys" aria-hidden="true">⌘K</kbd>
+        </button>
+        <a class="join-pill" href={join.href}>
+          <span class="join-label-full">{join.label}</span>
+          <span class="join-label-short">{join.short}</span>
+        </a>
         <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false" aria-label="Light mode">
           <svg
             class="theme-icon theme-icon-sun"
@@ -305,24 +322,57 @@ import MobileDrawer from './MobileDrawer.astro';
     margin-left: 0;
   }
 
+  .join-label-short {
+    display: none;
+  }
+
+  /* Two glyphs, not one: the lens says "search" without being read, and the keycap
+     teaches the shortcut. Square corners and a 34px box put it on the join pill's
+     baseline grid, so the right-hand controls read as one row of same-cut buttons
+     rather than a pill floating beside a rectangle. */
   .search-trigger {
-    background: none;
-    border: 1px solid var(--hairline);
-    border-radius: 4px;
+    align-items: center;
+    background: var(--wash-1);
+    border: 1px solid var(--hairline-card);
+    border-radius: 0;
     color: var(--text-2);
     cursor: pointer;
-    font-family: var(--font-mono);
-    font-size: 10px;
-    letter-spacing: 0.08em;
-    padding: 5px 8px;
+    display: inline-flex;
+    gap: 6px;
+    padding: 6px 5px 6px 9px;
     transition:
+      background-color 0.2s ease,
       border-color 0.2s ease,
       color 0.2s ease;
   }
 
+  .search-icon {
+    display: block;
+  }
+
+  .search-keys {
+    background: var(--wash-3);
+    border-radius: 2px;
+    color: var(--text-3);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    padding: 5px 6px;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
+  }
+
   .search-trigger:hover {
+    background: var(--wash-2);
     border-color: var(--accent-edge);
     color: var(--accent-ink);
+  }
+
+  .search-trigger:hover .search-keys {
+    background: var(--wash-4);
+    color: var(--text-2);
   }
 
   /* Accent text and strokes take --accent-ink, never --accent: the bright mint is
@@ -372,7 +422,41 @@ import MobileDrawer from './MobileDrawer.astro';
     display: none;
   }
 
-  @media (max-width: 950px) {
+  /* The desktop row's intrinsic minimum sat above the drawer breakpoint, so every
+     width between the two scrolled the page sideways. This tier spends the cheapest
+     levers — the row's own margins, then the search keycap, then the join pill's
+     label and padding — to pull that minimum from 1155 down to 1009. No nav label
+     is touched, so the menu reads the same the whole way down. Nav collapse sits at
+     1040 rather than 1009 so a wider mono fallback cannot close the gap. */
+  @media (max-width: 1180px) {
+    .header-row {
+      gap: 18px;
+      padding: 18px 28px;
+    }
+
+    .search-keys {
+      display: none;
+    }
+
+    .search-trigger {
+      padding: 6px 8px;
+    }
+
+    .join-pill {
+      letter-spacing: 0.06em;
+      padding: 9px 12px;
+    }
+
+    .join-label-full {
+      display: none;
+    }
+
+    .join-label-short {
+      display: inline;
+    }
+  }
+
+  @media (max-width: 1040px) {
     .header-row {
       align-items: flex-start;
       flex-wrap: wrap;
@@ -527,7 +611,7 @@ import MobileDrawer from './MobileDrawer.astro';
      sticky header off screen with it by however far the page was scrolled. The
      toggle that closes the drawer lives in this header, so while the drawer is
      open the header is pinned to the viewport and lifted over it. */
-  @media (max-width: 950px) {
+  @media (max-width: 1040px) {
     body.mobile-nav-open .site-header {
       inset-inline: 0;
       position: fixed;

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -274,7 +274,10 @@ export const wordmark = {
   secondary: 'ALIGNMENT + SAFETY',
 };
 
+/* `short` is the same destination under a narrower label: the header swaps to it
+   once the row runs out of room, rather than letting the pill push the page wide. */
 export const join = {
   label: 'JOIN / CONTACT',
+  short: 'JOIN',
   href: '/contact/?interest=newsletter#contact',
 };


### PR DESCRIPTION
## Search trigger

The trigger was a bare `⌘K` box: it named a shortcut without saying what the shortcut did, and at 10px it read as a caption rather than a control. It now carries a magnifier lens beside the keycap, so the affordance is legible before the label is read.

It sits in a 34px square-cornered box on the join pill's baseline, so the right-hand controls read as one row of same-cut buttons rather than a pill floating beside a rectangle, and it moves to sit directly left of the join pill — next to the action it most resembles.

## The overflow bug

More seriously, the header row had an intrinsic minimum of **1155px** while the drawer did not take over until **950px**. Every viewport in the 205px band between them scrolled the whole page sideways.

Padding, gap, the search keycap and the join pill's label and padding now compress below 1180px:

| lever | saved |
| --- | ---: |
| row padding 40→28, gap 26→18 | 40px |
| search collapses to lens only | 29px |
| `JOIN / CONTACT` → `JOIN` | 52px |

That pulls the row minimum from 1155 to **1009**. No nav label changes, so the menu reads the same at every width it is shown.

## Why nav collapse is 1040, not 1010

At 1010 the narrowest desktop viewport is 1011px against a 1009px row. Two pixels of headroom will not survive a font fallback rendering the mono a hair wider, so the breakpoint takes ~30px of real margin instead.

The cost is that 1024px laptops now get the drawer. The lever that would buy it back is shortening a nav label — `Policy & Frameworks` is 151px on its own, the widest item in the row — which is a content decision rather than a layout one, so it is deliberately not in this PR.

The breakpoint is written in **five places that must agree**: three `@media` blocks in `SiteHeader`, one in `MegaMenu`, one in `MobileDrawer`, plus `MobileDrawer`'s `matchMedia`. All five move together here. They have to — a toggle that appears while the drawer is still `display: none` flips `aria-expanded` and the body class while opening nothing at all.

## A second, unrelated overflow source

Fixing the header exposed it. `FootnoteBand` used `grid-template-columns: 1.15fr 0.85fr 250px`, and a bare `fr` track takes min-content as its automatic minimum, so the longest unbreakable link in a column pushed the grid past the page instead of the column shrinking to fit. Now `minmax(0, …)`.

The header fix alone would not have removed the scrollbar.

## Verification

- **Overflow sweep:** all 37 routes in `routes.json` across 20 widths from 1440 to 320 — 740 combinations — comparing `scrollWidth` against `clientWidth` and skipping any element inside an `overflow` container, so the marquee's deliberate clipping does not register as a false pass. **No horizontal overflow anywhere.**
- **Drawer:** confirmed to open at 1040, 1039, 1000, 900, 768, 600 and 420, with the 1041/1040 boundary exact — toggle hidden at 1041, toggle and drawer both live at 1040.
- `lint`, `format:check`, `check` (0 errors / 0 warnings / 0 hints, 122 files), `check:ratchet`, `check:styles-doc` all green.

## STYLES.md

Gains the two new tiers and records why nav collapse and the 950px layout breakpoint are no longer the same number. They were only ever equal by coincidence, and 950px still carries 117 unrelated uses across 45 files — without the note, someone grepping for the breakpoint will re-merge them.

## Follow-up

`MobileDrawer` uses `matchMedia('(min-width: 1041px)')` as the complement of `max-width: 1040px`. At a fractional viewport width — browser zoom, fractional DPI — 1040.5px satisfies neither, so CSS treats it as desktop while the resize handler that closes the drawer thinks it is mobile. A separate PR will replace it with `not all and (max-width: 1040px)`, which is the exact complement and cannot drift.
