### PR TITLE
fix(nav): derive the drawer's resize listener from the CSS boundary

### DIFF
--- a/STYLES.md
+++ b/STYLES.md
@@ -358,4 +358,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: 1b904480ab7cabf7e4675d6760e26a4ab272fb195f740a03fbeedddd1d799dc4 -->
+<!-- styles-hash: 2855ace87fa26f10b69dbe89eba19251dd4a59b88759eeef7d1991eb3f75a8c2 -->

--- a/src/components/MegaMenu.astro
+++ b/src/components/MegaMenu.astro
@@ -600,6 +600,8 @@ const initialProject = menus.oss.items![0]!;
     line-height: 1.45;
   }
 
+  /* Nav collapse; see the note in SiteHeader.astro. Hiding the desktop panel and
+     showing the drawer toggle are the same switch and share this number. */
   @media (max-width: 1040px) {
     .mega-panel {
       display: none;

--- a/src/components/MobileDrawer.astro
+++ b/src/components/MobileDrawer.astro
@@ -132,7 +132,15 @@ import { menus } from '../data/navigation';
         },
         { signal },
       );
-      matchMedia('(min-width: 1041px)').addEventListener(
+      // The negation of the CSS boundary, not `min-width: 1041px`. Two numbers
+      // have to be kept in step by hand, and they do not quite meet: at a
+      // fractional width like 1040.5 — browser zoom, fractional DPI — neither
+      // `max-width: 1040px` nor `min-width: 1041px` matches, so the CSS shows the
+      // desktop header while this listener still believes it is mobile and never
+      // closes the drawer. `not all and` is the exact complement and cannot drift.
+      // Nav collapse is written in five places that must agree; the others are
+      // the `@media` block below, two in SiteHeader.astro and one in MegaMenu.astro.
+      matchMedia('not all and (max-width: 1040px)').addEventListener(
         'change',
         (event) => {
           if (event.matches) this.closeMenu();
@@ -195,6 +203,8 @@ import { menus } from '../data/navigation';
     }
   }
 
+  /* Nav collapse; see the note in SiteHeader.astro. This block and the `matchMedia`
+     above are the same boundary from two sides — the listener negates this query. */
   @media (max-width: 1040px) {
     .mobile-drawer {
       background: var(--bg-panel);

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -456,6 +456,11 @@ import MobileDrawer from './MobileDrawer.astro';
     }
   }
 
+  /* Nav collapse: the desktop row swaps for the drawer. One of five copies that
+     must agree — the sticky-header block below, MegaMenu.astro, MobileDrawer.astro's
+     block and its `matchMedia`. Move them together: a toggle that appears while the
+     drawer is still `display: none` opens nothing at all. Above the row's measured
+     minimum by design; see the Breakpoints table in STYLES.md. */
   @media (max-width: 1040px) {
     .header-row {
       align-items: flex-start;
@@ -611,6 +616,7 @@ import MobileDrawer from './MobileDrawer.astro';
      sticky header off screen with it by however far the page was scrolled. The
      toggle that closes the drawer lives in this header, so while the drawer is
      open the header is pinned to the viewport and lifted over it. */
+  /* Nav collapse; see the note on the first 1040px block above. */
   @media (max-width: 1040px) {
     body.mobile-nav-open .site-header {
       inset-inline: 0;


### PR DESCRIPTION
Follow-up to #62.

## The defect

`MobileDrawer` closed the drawer on resize via `matchMedia('(min-width: 1041px)')` — hand-written as the complement of the CSS `max-width: 1040px`. Two numbers a human has to keep in step, and they do not quite meet.

At a fractional viewport width — browser zoom, fractional DPI — **1040.5px satisfies neither**:

| width | `min-width: 1041px` (old) | `not all and (max-width: 1040px)` (new) | CSS `max-width: 1040px` |
| ---: | --- | --- | --- |
| 1039 | false | false | true |
| 1040 | false | false | true |
| **1040.5** | **false** ← wrong | **true** | **false** |
| 1041 | true | true | false |
| 1200 | true | true | false |

At 1040.5 the CSS treats it as desktop and hides the toggle, while the listener still believes it is mobile. A drawer opened just below the boundary never closes, and the control that would close it is no longer on screen.

`not all and (max-width: 1040px)` is the exact negation of the CSS query, so the boundary exists once and no width can fall between the two. The old and new conditions agree at every integer width and disagree only where the old one was wrong.

## Cross-references

The number is written in five places that must agree — two `@media` blocks in `SiteHeader`, one in `MegaMenu`, one in `MobileDrawer`, and this listener. Each now carries a comment naming the other four and stating what breaks when they drift: a toggle that appears while the drawer is still `display: none` flips `aria-expanded` and the body class while opening nothing at all.

## Verification

- Media-query logic compared across 1039 / 1040 / 1040.5 / 1041 / 1200, as tabulated above.
- Live listener still closes a drawer opened at 900px when the viewport grows to 1200px.
- `lint`, `format`, `check` (0 errors / 0 warnings / 0 hints), `check:ratchet`, `check:styles-doc` green.

Comments only beyond the one condition; no rule changes, so no pixels move.

## What was deliberately left out

A ratchet check asserting the five copies agree. It would be ~30 lines of machinery policing a duplication rather than removing one, and it would not have caught the drift actually seen in practice — that came from a stale dev-server cache, not a source mismatch. The one-line change is the part that is net simpler: two numbers become one, and a rule you had to remember disappears.
