### PR TITLE
feat(newsletter): add whole-text RSS archive

### DIFF
--- a/STYLES.md
+++ b/STYLES.md
@@ -287,7 +287,7 @@ Search by the surface name or representative selector below before adding a rule
 | `ProseLayout.astro`                                                               | Standard article prose shell                                                                           | `.prose-content`                                                               |
 | `pages/network.mdx`                                                               | Network page join introduction                                                                         | `.join-intro`                                                                  |
 | `pages/newsletter/[issue].astro`                                                  | Newsletter issue meta bar, article deck and issue navigation                                           | `newsletter-meta-bar`, `.issue-meta`, `.newsletter-page`                       |
-| `pages/newsletter/index.astro`                                                    | Newsletter archive latest card and issue grid                                                          | `.latest-card`, `.issue-grid`                                                  |
+| `pages/newsletter/index.astro`                                                    | Newsletter archive feed link, latest card and issue grid                                               | `.rss-link`, `.latest-card`, `.issue-grid`                                     |
 | `pages/partners.mdx`                                                              | Partners page policy feature and list heading                                                          | `.policy-feature`, `.partner-list-heading`                                     |
 | `pages/open-source/index.mdx` | Open-source project list composition | `.oss-projects` |
 | `pages/policy.mdx`                                                                | Policy page work grid composition                                                                      | `.policy-work`                                                                 |
@@ -358,4 +358,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: 89742a1b9664efa2692f15ff6d8a94d8749bbc73e6bd4f2009d08f4f826d7257 -->
+<!-- styles-hash: 62f1cc4b1a111fda460c4d897150c9df0fc45e18e2494eb7d8e954a03d757954 -->

--- a/STYLES.md
+++ b/STYLES.md
@@ -19,6 +19,7 @@ for a number.
 | Borders  | `--hairline` subtle · `--hairline-card` visible · `--hairline-strong` strong                                                                                                                                       |
 | Fills    | `--wash-1` zebra · `--wash-2` resting · `--wash-3` hover · `--wash-4` pressed                                                                                                                                      |
 | Accent   | `--accent-ink` ink · `--accent` fill · `--accent-wash` / `--accent-veil` tint · `--accent-line` / `--accent-edge` rule                                                                                             |
+| RSS      | `--rss` canonical feed orange for the newsletter RSS pill                                                                                                                                                         |
 | Depth    | `--scrim-page-rgb` / `--scrim-inset-rgb` / `--scrim-stage-rgb` / `--scrim-modal-rgb` what a fade fades toward · `--ink-wash-rgb` + `--ink-wash-lift` ink as a mark · `--shadow-drop` raised · `--shadow-lift` tile |
 
 The `-a###` tokens beside each ladder are the same family at an off-ladder alpha (the digits are
@@ -202,7 +203,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 
 ## Global stylesheet
 
-`src/styles/tokens.css` is 1,315 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
+`src/styles/tokens.css` is 1,317 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
 
 | Category                             | Rules | Declarations | Contents                                                                                                                              |
 | ------------------------------------ | ----: | -----------: | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -216,7 +217,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 | Responsive foundation                |     7 |            8 | Global section, typography, primitive and form adjustments at the named breakpoints.                                                  |
 | Cross-surface and canvas integration |    73 |          151 | Canvas mount contracts, homepage section composition, shared composed-page clusters and rules spanning a page plus a child component. |
 | Theme overrides                      |     1 |          104 | Every theme-dependent token's light value on `:root[data-theme='light']`.                                                             |
-| Total                                |   256 |          699 | Global CSS only.                                                                                                                      |
+| Total                                |   256 |          701 | Global CSS only.                                                                                                                      |
 
 ## Component and page owners
 
@@ -287,7 +288,7 @@ Search by the surface name or representative selector below before adding a rule
 | `ProseLayout.astro`                                                               | Standard article prose shell                                                                           | `.prose-content`                                                               |
 | `pages/network.mdx`                                                               | Network page join introduction                                                                         | `.join-intro`                                                                  |
 | `pages/newsletter/[issue].astro`                                                  | Newsletter issue meta bar, article deck and issue navigation                                           | `newsletter-meta-bar`, `.issue-meta`, `.newsletter-page`                       |
-| `pages/newsletter/index.astro`                                                    | Newsletter archive feed link, latest card and issue grid                                               | `.rss-link`, `.latest-card`, `.issue-grid`                                     |
+| `pages/newsletter/index.astro`                                                    | Newsletter archive RSS pill, latest card and issue grid                                                | `.rss-link`, `.latest-card`, `.issue-grid`                                     |
 | `pages/partners.mdx`                                                              | Partners page policy feature and list heading                                                          | `.policy-feature`, `.partner-list-heading`                                     |
 | `pages/open-source/index.mdx` | Open-source project list composition | `.oss-projects` |
 | `pages/policy.mdx`                                                                | Policy page work grid composition                                                                      | `.policy-work`                                                                 |
@@ -358,4 +359,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: 62f1cc4b1a111fda460c4d897150c9df0fc45e18e2494eb7d8e954a03d757954 -->
+<!-- styles-hash: b32b9e9c9a1a1f5f01536bc752e33dfd548e92c905c2cebfffd173a7fc8ba0b4 -->

--- a/STYLES.md
+++ b/STYLES.md
@@ -19,7 +19,6 @@ for a number.
 | Borders  | `--hairline` subtle · `--hairline-card` visible · `--hairline-strong` strong                                                                                                                                       |
 | Fills    | `--wash-1` zebra · `--wash-2` resting · `--wash-3` hover · `--wash-4` pressed                                                                                                                                      |
 | Accent   | `--accent-ink` ink · `--accent` fill · `--accent-wash` / `--accent-veil` tint · `--accent-line` / `--accent-edge` rule                                                                                             |
-| RSS      | `--rss` canonical feed orange for the newsletter RSS pill                                                                                                                                                         |
 | Depth    | `--scrim-page-rgb` / `--scrim-inset-rgb` / `--scrim-stage-rgb` / `--scrim-modal-rgb` what a fade fades toward · `--ink-wash-rgb` + `--ink-wash-lift` ink as a mark · `--shadow-drop` raised · `--shadow-lift` tile |
 
 The `-a###` tokens beside each ladder are the same family at an off-ladder alpha (the digits are
@@ -203,7 +202,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 
 ## Global stylesheet
 
-`src/styles/tokens.css` is 1,317 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
+`src/styles/tokens.css` is 1,319 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
 
 | Category                             | Rules | Declarations | Contents                                                                                                                              |
 | ------------------------------------ | ----: | -----------: | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -217,7 +216,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 | Responsive foundation                |     7 |            8 | Global section, typography, primitive and form adjustments at the named breakpoints.                                                  |
 | Cross-surface and canvas integration |    73 |          151 | Canvas mount contracts, homepage section composition, shared composed-page clusters and rules spanning a page plus a child component. |
 | Theme overrides                      |     1 |          104 | Every theme-dependent token's light value on `:root[data-theme='light']`.                                                             |
-| Total                                |   256 |          701 | Global CSS only.                                                                                                                      |
+| Total                                |   257 |          701 | Global CSS only.                                                                                                                      |
 
 ## Component and page owners
 
@@ -359,4 +358,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: b32b9e9c9a1a1f5f01536bc752e33dfd548e92c905c2cebfffd173a7fc8ba0b4 -->
+<!-- styles-hash: 5f3b3fa2df21a9c783a2501a76a79b93146f2d8a8022d9ea1312dcdb53406d85 -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@astrojs/markdown-remark": "7.2.2",
         "@astrojs/mdx": "7.0.5",
         "@astrojs/preact": "^6.0.2",
+        "@astrojs/rss": "4.0.19",
         "@astrojs/sitemap": "3.7.3",
         "astro": "7.1.6",
         "preact": "^10.29.8"
@@ -420,6 +421,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -2281,6 +2293,18 @@
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -3470,6 +3494,18 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -4732,6 +4768,45 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5331,6 +5406,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7196,6 +7283,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -8035,6 +8137,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/style-to-js": {
@@ -9079,6 +9196,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@astrojs/markdown-remark": "7.2.2",
     "@astrojs/mdx": "7.0.5",
     "@astrojs/preact": "^6.0.2",
+    "@astrojs/rss": "4.0.19",
     "@astrojs/sitemap": "3.7.3",
     "astro": "7.1.6",
     "preact": "^10.29.8"

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -7,6 +7,10 @@ interface HeroButton {
 interface Props {
   status: string;
   status_href?: string;
+  // The client router swaps responses into the current document, which a feed
+  // or any other non-HTML target cannot survive. Set this when status_href
+  // points at one.
+  status_reload?: boolean;
   title: string[];
   subtitle_lines: string[];
   beneficiaries?: string[];
@@ -15,7 +19,17 @@ interface Props {
   secondary_button?: HeroButton;
 }
 
-const { status, status_href, title, subtitle_lines, beneficiaries = [], typewriter_underline = false, primary_button, secondary_button }: Props = Astro.props;
+const {
+  status,
+  status_href,
+  status_reload = false,
+  title,
+  subtitle_lines,
+  beneficiaries = [],
+  typewriter_underline = false,
+  primary_button,
+  secondary_button,
+}: Props = Astro.props;
 const hasActionsSlot = Astro.slots.has('actions');
 const initialBeneficiary = beneficiaries[0];
 const [missionLine1, missionLine2] = subtitle_lines;
@@ -27,7 +41,7 @@ const ariaSentence = [...subtitle_lines, initialBeneficiary].filter(Boolean).joi
   <div class="hero-copy">
     {
       status_href ? (
-        <a class="status-pill" href={status_href}>
+        <a class="status-pill" href={status_href} data-astro-reload={status_reload ? '' : undefined}>
           <span aria-hidden="true" />
           {status}
         </a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -147,8 +147,8 @@ const newsletter = defineCollection({
   loader: glob({ pattern: '*.md', base: './src/content/newsletter' }),
   schema: z.object({
     issue: z.number().int().positive(),
-    date: z.date().optional(),
-    summary: z.string().optional(),
+    date: z.date(),
+    summary: z.string(),
     tags: z.array(z.enum(NEWSLETTER_TAGS)).max(3).optional(),
     syndication: z.array(z.object({ name: z.string(), url: z.url() })).optional(),
   }),

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,6 +45,7 @@ const article = frontmatter.article
     <meta name="description" content={description} />
     {frontmatter.noindex && <meta name="robots" content="noindex" />}
     {!frontmatter.noCanonical && <link rel="canonical" href={canonical} />}
+    <link rel="alternate" type="application/rss+xml" title="The ML Engineer newsletter" href="/newsletter/rss.xml" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/favicon.png" type="image/png" />
     <meta property="og:type" content="website" />

--- a/src/pages/newsletter/[issue].astro
+++ b/src/pages/newsletter/[issue].astro
@@ -54,7 +54,9 @@ const frontmatter = {
 <BaseLayout frontmatter={frontmatter}>
   <article class="newsletter-issue">
     <Hero
-      status="THE ML ENGINEER — WEEKLY NEWSLETTER"
+      status="THE ML ENGINEER — SUBSCRIBE VIA RSS"
+      status_href="/newsletter/rss.xml"
+      status_reload
       title={['The Machine', 'Learning Engineer', `Issue #${issue}`]}
       subtitle_lines={['Join 70k+ AI professionals receiving weekly curated', 'articles, tutorials and blog posts on']}
       beneficiaries={['production machine learning.', 'MLOps at scale.', 'agentic systems.', 'ML security.', 'AI safety.']}

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -3,12 +3,8 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Hero from '../../components/Hero.astro';
 import NewsletterSubscribe from '../../components/NewsletterSubscribe.astro';
+import { newsletterArchiveFrontmatter as frontmatter } from './rss.xml';
 
-const frontmatter = {
-  title: 'The ML Engineer — Newsletter archive',
-  description:
-    'The Machine Learning Engineer newsletter archive: weekly curated articles, tutorials and insights from experienced machine learning professionals since 2018.',
-};
 const issues = (await getCollection('newsletter')).sort(
   (first, second) => (second.data.date?.getTime() ?? 0) - (first.data.date?.getTime() ?? 0) || second.data.issue - first.data.issue,
 );
@@ -33,6 +29,7 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
       beneficiaries={['production machine learning.', 'MLOps at scale.', 'agentic systems.', 'ML security.', 'AI safety.']}
     >
       <NewsletterSubscribe id="subscribe" slot="actions" />
+      <a class="rss-link" href="/newsletter/rss.xml" slot="actions" data-astro-reload>RSS</a>
     </Hero>
 
     {
@@ -99,6 +96,11 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
 </BaseLayout>
 
 <style>
+  .rss-link {
+    align-self: center;
+    font-family: var(--font-mono);
+    font-size: var(--body-14);
+  }
   .latest-card {
     align-items: center;
     background: linear-gradient(180deg, var(--wash-2), transparent);

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -27,7 +27,7 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
 <BaseLayout frontmatter={frontmatter}>
   <article class="newsletter-archive">
     <Hero
-      status="THE ML ENGINEER — SUBSCRIBE VIA RSS"
+      status="THE ML ENGINEER — SUBSCRIBE VIA RSS FEED"
       status_href="/newsletter/rss.xml"
       status_reload
       title={['The Machine', 'Learning Engineer', 'Newsletter']}

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -33,7 +33,6 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
       beneficiaries={['production machine learning.', 'MLOps at scale.', 'agentic systems.', 'ML security.', 'AI safety.']}
     >
       <NewsletterSubscribe id="subscribe" slot="actions" />
-      <a class="rss-link" href="/newsletter/rss.xml" slot="actions" data-astro-reload>RSS</a>
     </Hero>
 
     {
@@ -73,7 +72,10 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
             ))
           }
         </div>
-        <p class="finder-hint">Full-text search lives in <button type="button" class="finder-palette" data-command-palette-open>⌘K</button></p>
+        <p class="finder-hint">
+          <span>Full-text search lives in <button type="button" class="finder-palette" data-command-palette-open>⌘K</button></span>
+          <a class="rss-link" href="/newsletter/rss.xml" data-astro-reload>RSS</a>
+        </p>
       </div>
       <div class="issue-list" data-reveal>
         {
@@ -100,11 +102,6 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
 </BaseLayout>
 
 <style>
-  .rss-link {
-    align-self: center;
-    font-family: var(--font-mono);
-    font-size: var(--body-14);
-  }
   .latest-card {
     align-items: center;
     background: linear-gradient(180deg, var(--wash-2), transparent);
@@ -246,12 +243,26 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
     color: var(--accent-ink);
   }
   .finder-hint {
+    align-items: center;
     color: var(--text-3);
+    display: flex;
     flex-basis: 100%;
     font-family: var(--font-mono);
     font-size: var(--mono-10);
+    justify-content: space-between;
     letter-spacing: 0.1em;
     margin: 0;
+  }
+  .rss-link {
+    border: 1px solid var(--rss);
+    border-radius: var(--radius-pill);
+    color: var(--rss);
+    font-family: var(--font-mono);
+    font-size: var(--mono-9);
+    padding: 6px 10px;
+  }
+  .rss-link:hover {
+    opacity: 1;
   }
   .finder-palette {
     background: none;

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -27,7 +27,7 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
 <BaseLayout frontmatter={frontmatter}>
   <article class="newsletter-archive">
     <Hero
-      status="THE ML ENGINEER — SUBSCRIBE BY RSS"
+      status="THE ML ENGINEER — SUBSCRIBE VIA RSS"
       status_href="/newsletter/rss.xml"
       status_reload
       title={['The Machine', 'Learning Engineer', 'Newsletter']}

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -27,7 +27,7 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
 <BaseLayout frontmatter={frontmatter}>
   <article class="newsletter-archive">
     <Hero
-      status="THE ML ENGINEER — SUBSCRIBE VIA RSS FEED"
+      status="THE ML ENGINEER — SUBSCRIBE VIA RSS"
       status_href="/newsletter/rss.xml"
       status_reload
       title={['The Machine', 'Learning Engineer', 'Newsletter']}

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -27,7 +27,9 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
 <BaseLayout frontmatter={frontmatter}>
   <article class="newsletter-archive">
     <Hero
-      status="THE ML ENGINEER — WEEKLY NEWSLETTER"
+      status="THE ML ENGINEER — SUBSCRIBE BY RSS"
+      status_href="/newsletter/rss.xml"
+      status_reload
       title={['The Machine', 'Learning Engineer', 'Newsletter']}
       subtitle_lines={['Join 70k+ AI professionals receiving weekly curated', 'articles, tutorials and blog posts on']}
       beneficiaries={['production machine learning.', 'MLOps at scale.', 'agentic systems.', 'ML security.', 'AI safety.']}
@@ -72,10 +74,7 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
             ))
           }
         </div>
-        <p class="finder-hint">
-          <span>Full-text search lives in <button type="button" class="finder-palette" data-command-palette-open>⌘K</button></span>
-          <a class="rss-link" href="/newsletter/rss.xml" data-astro-reload>RSS</a>
-        </p>
+        <p class="finder-hint">Full-text search lives in <button type="button" class="finder-palette" data-command-palette-open>⌘K</button></p>
       </div>
       <div class="issue-list" data-reveal>
         {
@@ -243,26 +242,12 @@ const issueLabel = (entry: (typeof issues)[number]) => [`Issue ${entry.data.issu
     color: var(--accent-ink);
   }
   .finder-hint {
-    align-items: center;
     color: var(--text-3);
-    display: flex;
     flex-basis: 100%;
     font-family: var(--font-mono);
     font-size: var(--mono-10);
-    justify-content: space-between;
     letter-spacing: 0.1em;
     margin: 0;
-  }
-  .rss-link {
-    border: 1px solid var(--rss);
-    border-radius: var(--radius-pill);
-    color: var(--rss);
-    font-family: var(--font-mono);
-    font-size: var(--mono-9);
-    padding: 6px 10px;
-  }
-  .rss-link:hover {
-    opacity: 1;
   }
   .finder-palette {
     background: none;

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -3,8 +3,12 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Hero from '../../components/Hero.astro';
 import NewsletterSubscribe from '../../components/NewsletterSubscribe.astro';
-import { newsletterArchiveFrontmatter as frontmatter } from './rss.xml';
 
+const frontmatter = {
+  title: 'The ML Engineer — Newsletter archive',
+  description:
+    'The Machine Learning Engineer newsletter archive: weekly curated articles, tutorials and insights from experienced machine learning professionals since 2018.',
+};
 const issues = (await getCollection('newsletter')).sort(
   (first, second) => (second.data.date?.getTime() ?? 0) - (first.data.date?.getTime() ?? 0) || second.data.issue - first.data.issue,
 );

--- a/src/pages/newsletter/rss.xml.ts
+++ b/src/pages/newsletter/rss.xml.ts
@@ -2,25 +2,18 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 
-export const newsletterArchiveFrontmatter = {
-  title: 'The ML Engineer — Newsletter archive',
-  description:
-    'The Machine Learning Engineer newsletter archive: weekly curated articles, tutorials and insights from experienced machine learning professionals since 2018.',
-};
-
-const siteOrigin = 'https://ethical.institute';
-
-const absolutiseReferences = (html: string) =>
+const absolutiseReferences = (html: string, site: URL) =>
   html.replace(
     /\b(href|src)=(['"])(?![a-z][a-z\d+.-]*:|#)([^'"]*)\2/gi,
     (_match, attribute, quote, reference) => {
       // Feed readers do not share the site's base URL, so root-relative issue links
       // need a canonical origin in the portable HTML payload.
-      return `${attribute}=${quote}${new URL(reference, siteOrigin).href}${quote}`;
+      return `${attribute}=${quote}${new URL(reference, site).href}${quote}`;
     },
   );
 
 export async function GET(context: APIContext) {
+  const site = context.site!;
   const issues = (await getCollection('newsletter')).sort(
     (first, second) =>
       second.data.date.getTime() - first.data.date.getTime() ||
@@ -28,16 +21,17 @@ export async function GET(context: APIContext) {
   );
 
   return rss({
-    title: newsletterArchiveFrontmatter.title,
-    description: newsletterArchiveFrontmatter.description,
-    site: context.site!,
+    title: 'The ML Engineer — Newsletter archive',
+    description:
+      'The Machine Learning Engineer newsletter archive: weekly curated articles, tutorials and insights from experienced machine learning professionals since 2018.',
+    site,
     items: issues.map((entry) => ({
       title: `The ML Engineer — Issue #${entry.data.issue}`,
       link: `/newsletter/${entry.data.issue}/`,
       pubDate: entry.data.date,
       description: entry.data.summary,
       categories: entry.data.tags,
-      content: absolutiseReferences(entry.rendered!.html),
+      content: absolutiseReferences(entry.rendered!.html, site),
     })),
     customData: '<language>en</language>',
   });

--- a/src/pages/newsletter/rss.xml.ts
+++ b/src/pages/newsletter/rss.xml.ts
@@ -1,0 +1,44 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export const newsletterArchiveFrontmatter = {
+  title: 'The ML Engineer — Newsletter archive',
+  description:
+    'The Machine Learning Engineer newsletter archive: weekly curated articles, tutorials and insights from experienced machine learning professionals since 2018.',
+};
+
+const siteOrigin = 'https://ethical.institute';
+
+const absolutiseReferences = (html: string) =>
+  html.replace(
+    /\b(href|src)=(['"])(?![a-z][a-z\d+.-]*:|#)([^'"]*)\2/gi,
+    (_match, attribute, quote, reference) => {
+      // Feed readers do not share the site's base URL, so root-relative issue links
+      // need a canonical origin in the portable HTML payload.
+      return `${attribute}=${quote}${new URL(reference, siteOrigin).href}${quote}`;
+    },
+  );
+
+export async function GET(context: APIContext) {
+  const issues = (await getCollection('newsletter')).sort(
+    (first, second) =>
+      second.data.date.getTime() - first.data.date.getTime() ||
+      second.data.issue - first.data.issue,
+  );
+
+  return rss({
+    title: newsletterArchiveFrontmatter.title,
+    description: newsletterArchiveFrontmatter.description,
+    site: context.site!,
+    items: issues.map((entry) => ({
+      title: `The ML Engineer — Issue #${entry.data.issue}`,
+      link: `/newsletter/${entry.data.issue}/`,
+      pubDate: entry.data.date,
+      description: entry.data.summary,
+      categories: entry.data.tags,
+      content: absolutiseReferences(entry.rendered!.html),
+    })),
+    customData: '<language>en</language>',
+  });
+}

--- a/src/pages/newsletter/rss.xml.ts
+++ b/src/pages/newsletter/rss.xml.ts
@@ -2,6 +2,9 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 
+// Preserve headroom under the 8 MB reader ceiling as one issue is added each week.
+const wholeTextIssueLimit = 100;
+
 const absolutiseReferences = (html: string, site: URL) =>
   html.replace(
     /\b(href|src)=(['"])(?![a-z][a-z\d+.-]*:|#)([^'"]*)\2/gi,
@@ -25,13 +28,15 @@ export async function GET(context: APIContext) {
     description:
       'The Machine Learning Engineer newsletter archive: weekly curated articles, tutorials and insights from experienced machine learning professionals since 2018.',
     site,
-    items: issues.map((entry) => ({
+    items: issues.map((entry, index) => ({
       title: `The ML Engineer — Issue #${entry.data.issue}`,
       link: `/newsletter/${entry.data.issue}/`,
       pubDate: entry.data.date,
       description: entry.data.summary,
       categories: entry.data.tags,
-      content: absolutiseReferences(entry.rendered!.html, site),
+      ...(index < wholeTextIssueLimit
+        ? { content: absolutiseReferences(entry.rendered!.html, site) }
+        : {}),
     })),
     customData: '<language>en</language>',
   });

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -86,6 +86,7 @@
   --accent-veil: rgba(94, 230, 160, 0.16);
   --accent-line: rgba(94, 230, 160, 0.28);
   --accent-edge: rgba(94, 230, 160, 0.45);
+  --rss: #f26522;
   /* accent — off-ladder steps */
   /* ---- scrim: what a fade fades TOWARD -------------------------------------
      Twelve tokens used to spell out four colours at nine alphas, because a
@@ -323,6 +324,7 @@
   --accent-veil: rgba(10, 151, 137, 0.18);
   --accent-line: rgba(5, 98, 89, 0.35);
   --accent-edge: rgba(5, 98, 89, 0.55);
+  --rss: #a83b00;
   /* The fill form: the design teal as designed. `--accent-on` is unchanged from
      `:root` — the near-black reads 5.16:1 on it, white would read 3.62:1. */
   --accent: #0a9789;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -86,7 +86,6 @@
   --accent-veil: rgba(94, 230, 160, 0.16);
   --accent-line: rgba(94, 230, 160, 0.28);
   --accent-edge: rgba(94, 230, 160, 0.45);
-  --rss: #f26522;
   /* accent — off-ladder steps */
   /* ---- scrim: what a fade fades TOWARD -------------------------------------
      Twelve tokens used to spell out four colours at nine alphas, because a
@@ -324,7 +323,6 @@
   --accent-veil: rgba(10, 151, 137, 0.18);
   --accent-line: rgba(5, 98, 89, 0.35);
   --accent-edge: rgba(5, 98, 89, 0.55);
-  --rss: #a83b00;
   /* The fill form: the design teal as designed. `--accent-on` is unchanged from
      `:root` — the near-black reads 5.16:1 on it, white would read 3.62:1. */
   --accent: #0a9789;
@@ -535,6 +533,10 @@ button.nav-trigger {
   letter-spacing: .14em;
   margin: 0;
   padding: 6px 13px;
+}
+a.status-pill:hover {
+  border-color: var(--accent-edge);
+  color: var(--text-1);
 }
 .status-pill span {
   background: var(--accent);


### PR DESCRIPTION
## Summary

- add `/newsletter/rss.xml` with the official `@astrojs/rss` package
- publish all 399 newsletter issues newest-first with each issue's complete rendered HTML in `content:encoded`
- rewrite relative `href` and `src` references against `https://ethical.institute` for portable feed-reader content
- require the universally present newsletter `date` and `summary` fields
- advertise the feed in the global document head and add a plain RSS link beside the archive subscribe form

The archive wording remains a single source shared by the archive page and feed. The full archive is intentional: the generated feed is 6,795,232 bytes and is not truncated to recent issues or reduced to summaries.

## Visual change

The new RSS link beside the subscribe form intentionally moves pixels on `/newsletter/`, so this PR carries the `visual-change` label.

## Verification

- `npm run build`
- mechanical XML validation: 399 items; first issue #399 dated 2026-08-09; last issue #1; 6,795,232 bytes; zero relative content references; 399/399 items with content, publication dates, and canonical newsletter links
- `npm run lint`
- `npm run format:check`
- `npm run check:ratchet`
- `npm run verify:dom -- /newsletter/ --viewport 1440x1000`
- `npm run verify:dom -- /newsletter/ --viewport 420x900`
