### PR TITLE
feat(seo): topical titles and descriptions from the phase-2 intent audit

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,7 +9,8 @@ const metaDescription = 'An independent research institute working to ensure tha
 const ogImage = '/images/banner.jpg';
 const { frontmatter = {} } = Astro.props;
 const title = frontmatter.title ?? 'The Institute for Ethical AI Alignment & Safety';
-const description = frontmatter.description ?? metaDescription;
+const seoTitle = frontmatter.seoTitle ?? title;
+const description = frontmatter.seoDescription ?? frontmatter.description ?? metaDescription;
 const canonical = new URL(Astro.url.pathname, Astro.site);
 const socialImage = new URL(frontmatter.image ?? ogImage, Astro.site);
 const organization = {
@@ -49,12 +50,12 @@ const article = frontmatter.article
     <link rel="icon" href="/favicon.png" type="image/png" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="The Institute for Ethical AI Alignment & Safety" />
-    <meta property="og:title" content={title} />
+    <meta property="og:title" content={seoTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={socialImage} />
     <meta property="og:url" content={canonical} />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content={title} />
+    <meta name="twitter:title" content={seoTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={socialImage} />
     <script is:inline type="application/ld+json" set:html={JSON.stringify(organization)} />
@@ -171,7 +172,7 @@ const article = frontmatter.article
         });
       });
     </script>
-    <title>{title}</title>
+    <title>{seoTitle}</title>
   </head>
   <body>
     <SiteHeader />

--- a/src/layouts/PrincipleLayout.astro
+++ b/src/layouts/PrincipleLayout.astro
@@ -6,7 +6,7 @@ import KaosGraph from '../components/KaosGraph.astro';
 const { data, Content } = Astro.props;
 const frontmatter = {
   title: `${data.number}. ${data.title}`,
-  seoTitle: `${data.title} — Responsible AI Principle ${Number(data.number)}`,
+  seoTitle: `${data.title} — Alignment & Safety Principle ${Number(data.number)}`,
   description: data.description,
   eyebrow: `PRINCIPLE ${data.number} — COMMITMENT`,
   transitionName: `principle-title-${data.number}`,

--- a/src/layouts/PrincipleLayout.astro
+++ b/src/layouts/PrincipleLayout.astro
@@ -6,6 +6,7 @@ import KaosGraph from '../components/KaosGraph.astro';
 const { data, Content } = Astro.props;
 const frontmatter = {
   title: `${data.number}. ${data.title}`,
+  seoTitle: `${data.title} — Responsible AI Principle ${Number(data.number)}`,
   description: data.description,
   eyebrow: `PRINCIPLE ${data.number} — COMMITMENT`,
   transitionName: `principle-title-${data.number}`,

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -1,5 +1,6 @@
 ---
 title: About the Institute
+seoTitle: About the Institute for Ethical AI Alignment & Safety
 description: Learn about the Institute's history, mission and independent work to make frontier AI safe, aligned and accountable to people and society.
 layout: ../layouts/ProseLayout.astro
 ---

--- a/src/pages/frameworks/agentic-maturity-model.mdx
+++ b/src/pages/frameworks/agentic-maturity-model.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agentic Maturity Model
+title: Agentic Maturity Model — Capability Levels for AI Agents
 description: Organisational capability levels for operating agentic systems, currently in development.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/frameworks/agentic-rfx.mdx
+++ b/src/pages/frameworks/agentic-rfx.mdx
@@ -1,5 +1,5 @@
 ---
-title: The Agentic RFX Framework
+title: Agentic RFX — Procurement Criteria for Agentic AI Systems
 description: Procurement criteria for agentic systems, in development as an extension of the AI-RFX framework.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/frameworks/ai-rfx.mdx
+++ b/src/pages/frameworks/ai-rfx.mdx
@@ -1,5 +1,5 @@
 ---
-title: The AI-RFX Procurement Framework
+title: AI-RFX — Open Procurement Framework and RFP Templates for AI
 description: Open-source templates that convert the nine Responsible AI Principles into a procurement checklist for organisations buying, building or deploying AI systems.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/frameworks/index.mdx
+++ b/src/pages/frameworks/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Responsible AI Frameworks — Procurement, Maturity, Security
+title: AI Safety Frameworks — Procurement, Maturity, Security
 description: Procurement, maturity and security frameworks that translate the nine Responsible AI Principles into practice.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/frameworks/index.mdx
+++ b/src/pages/frameworks/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Frameworks
+title: Responsible AI Frameworks — Procurement, Maturity, Security
 description: Procurement, maturity and security frameworks that translate the nine Responsible AI Principles into practice.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/frameworks/maturity-model.mdx
+++ b/src/pages/frameworks/maturity-model.mdx
@@ -1,5 +1,5 @@
 ---
-title: Machine Learning Maturity Model
+title: Machine Learning Maturity Model — Eight Assessment Criteria
 description: Make responsible ML repeatable through a practical path from isolated good intentions to adaptive organisational capability.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/frameworks/security.mdx
+++ b/src/pages/frameworks/security.mdx
@@ -1,5 +1,5 @@
 ---
-title: MLSecOps & Agentic Security
+title: MLSecOps — Machine Learning and Agentic AI Security Guidance
 description: MLSecOps security guidance for the machine-learning lifecycle, extended to agentic systems with delegated authority, tools and memory.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/network.mdx
+++ b/src/pages/network.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ethical AI Network
+title: Ethical AI Network — Practitioners in ML, Policy & Standards
 description: The ML Engineer newsletter and Ethical AI Network connect practitioners working across engineering, research, policy and standards.
 composed: true
 layout: ../layouts/ProseLayout.astro

--- a/src/pages/newsletter/[issue].astro
+++ b/src/pages/newsletter/[issue].astro
@@ -38,9 +38,14 @@ const truncateDescription = (value: string, maxLength = 160) => {
   const candidate = value.slice(0, maxLength - 1).trimEnd();
   return `${candidate.slice(0, candidate.lastIndexOf(' ')).replace(/[,:;]+$/, '')}…`;
 };
+const issueTitleFallback = `The ML Engineer — Issue #${issue}`;
+const issueTitleSuffix = ` — The ML Engineer #${issue}`;
+const topicLeadSource = entry.data.summary?.split(',').slice(0, 2).join(',').trim();
+const topicLeadLimit = Math.min(45, 65 - issueTitleSuffix.length);
+const topicLead = topicLeadSource ? truncateDescription(topicLeadSource, topicLeadLimit).replace(/…$/, '') : undefined;
 
 const frontmatter = {
-  title: `The ML Engineer — Issue #${issue}`,
+  title: topicLead ? `${topicLead}${issueTitleSuffix}` : issueTitleFallback,
   description: truncateDescription(
     entry.data.summary ?? 'The Machine Learning Engineer newsletter: curated articles, tutorials and insights from experienced machine learning professionals.',
   ),

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -5,7 +5,7 @@ import Hero from '../../components/Hero.astro';
 import NewsletterSubscribe from '../../components/NewsletterSubscribe.astro';
 
 const frontmatter = {
-  title: 'The ML Engineer — Newsletter archive',
+  title: 'The ML Engineer — Weekly Production ML & MLOps Newsletter',
   description:
     'The Machine Learning Engineer newsletter archive: weekly curated articles, tutorials and insights from experienced machine learning professionals since 2018.',
 };

--- a/src/pages/open-source/ai-guidelines.mdx
+++ b/src/pages/open-source/ai-guidelines.mdx
@@ -1,5 +1,6 @@
 ---
 title: Awesome AI Regulation, Principles & Guidelines
+seoTitle: Awesome AI Regulation & Guidelines — Global Policy Map
 description: An open catalogue mapping AI guidelines, principles, ethics codes, standards and regulation, from national law to practical checklists.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/open-source/ai-guidelines.mdx
+++ b/src/pages/open-source/ai-guidelines.mdx
@@ -1,6 +1,6 @@
 ---
 title: Awesome AI Regulation, Principles & Guidelines
-seoTitle: Awesome AI Regulation & Guidelines — Global Policy Map
+seoTitle: AI Regulation & Guidelines — Global Policy Map
 description: An open catalogue mapping AI guidelines, principles, ethics codes, standards and regulation, from national law to practical checklists.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/open-source/index.mdx
+++ b/src/pages/open-source/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Open source & tools
+title: Open-Source AI and MLOps Tools from the Institute
 description: Openly licensed software for agent orchestration, GPU compute, explainability and production ML.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/open-source/kaos.mdx
+++ b/src/pages/open-source/kaos.mdx
@@ -2,6 +2,8 @@
 layout: ../../layouts/ProseLayout.astro
 title: K8s Agent OS (KAOS)
 description: Deploy, manage and orchestrate AI agents on Kubernetes as declarative resources, secured at the gateway and observable end to end with KAOS.
+seoTitle: KAOS — Kubernetes Agent Orchestration System for AI Agents
+seoDescription: Deploy, manage and orchestrate AI agents on Kubernetes as declarative custom resources — scoped credentials, budgets, approval gates, gateway security and end-to-end observability.
 composed: true
 
 quickstart:

--- a/src/pages/open-source/kompute.mdx
+++ b/src/pages/open-source/kompute.mdx
@@ -1,5 +1,6 @@
 ---
 title: Kompute
+seoTitle: Kompute — Vulkan GPU Compute Framework (Linux Foundation)
 description: A fast, mobile-enabled and asynchronous general-purpose GPU compute framework for cross-vendor graphics cards from AMD, Qualcomm, NVIDIA and others.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/open-source/production-ml-list.mdx
+++ b/src/pages/open-source/production-ml-list.mdx
@@ -1,6 +1,6 @@
 ---
 title: Awesome Production Machine Learning
-seoTitle: Awesome Production Machine Learning — 545 MLOps Tools
+seoTitle: Production Machine Learning — 545 Open-Source MLOps Tools
 description: A curated catalogue of 545 open-source libraries across 24 categories for deploying, monitoring, versioning and scaling machine learning.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/open-source/production-ml-list.mdx
+++ b/src/pages/open-source/production-ml-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: Awesome Production Machine Learning
+seoTitle: Awesome Production Machine Learning — 545 MLOps Tools
 description: A curated catalogue of 545 open-source libraries across 24 categories for deploying, monitoring, versioning and scaling machine learning.
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/open-source/xai.mdx
+++ b/src/pages/open-source/xai.mdx
@@ -1,5 +1,6 @@
 ---
 title: XAI — an eXplainability toolbox for machine learning
+seoTitle: XAI — Explainability and Bias Toolbox for Machine Learning
 description: 'XAI is a machine learning library for explainability across data analysis, model evaluation and production monitoring, bringing tools and process together.'
 composed: true
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/partners.mdx
+++ b/src/pages/partners.mdx
@@ -1,5 +1,5 @@
 ---
-title: Partners
+title: Partners — Institutions Working with the Institute
 description: Organisations work with the Institute through frameworks, open source, the network, and standards and policy engagement.
 composed: true
 layout: ../layouts/ProseLayout.astro

--- a/src/pages/policy.mdx
+++ b/src/pages/policy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Policy & standards
+title: AI Policy & Standards — EU AI Act, UK, UN and ISO Engagement
 description: Practitioner evidence, public-policy products and standards participation across European, UK, UN and US processes.
 composed: true
 layout: ../layouts/ProseLayout.astro

--- a/src/pages/principles/index.mdx
+++ b/src/pages/principles/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: The Responsible Machine Learning Principles — Nine Commitments
-description: 'The nine Responsible Machine Learning Principles: commitments, failure modes and the practical controls that implement them, for teams deploying, integrating and fine-tuning AI systems.'
+title: The Nine Principles for AI Alignment & Safety
+description: 'The nine principles for AI alignment and safety: commitments, failure modes and the practical controls that implement them, for teams deploying, integrating and fine-tuning AI systems.'
 composed: true
 layout: ../../layouts/ProseLayout.astro
 ---

--- a/src/pages/principles/index.mdx
+++ b/src/pages/principles/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: The nine Responsible AI Principles
-description: The principles apply to individual decisions and institutional controls.
+title: The Responsible Machine Learning Principles — Nine Commitments
+description: 'The nine Responsible Machine Learning Principles: commitments, failure modes and the practical controls that implement them, for teams deploying, integrating and fine-tuning AI systems.'
 composed: true
 layout: ../../layouts/ProseLayout.astro
 ---

--- a/src/pages/reports/index.mdx
+++ b/src/pages/reports/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: State of Production ML reports
+seoTitle: State of Production ML Surveys — Methodology and Citation
 description: The 2024 and 2025 State of Production ML practitioner surveys, with respondent counts, field dates, methodology and citation guidance.
 eyebrow: REPORTS & DATA
 layout: ../../layouts/ProseLayout.astro

--- a/src/pages/reports/state-of-ml-2024.mdx
+++ b/src/pages/reports/state-of-ml-2024.mdx
@@ -1,5 +1,6 @@
 ---
 title: The State of Production ML in 2024
+seoTitle: The State of Production ML 2024 — MLOps Practitioner Survey
 description: Practitioner-reported production machine learning practices, tools, organisational context and demographics from the 2024 survey.
 composed: true
 article: true

--- a/src/pages/reports/state-of-ml-2025.mdx
+++ b/src/pages/reports/state-of-ml-2025.mdx
@@ -1,5 +1,6 @@
 ---
 title: The State of Production ML in 2025
+seoTitle: The State of Production ML 2025 — MLOps Practitioner Survey
 description: Practitioner-reported production machine learning practices, tools, organisational context and demographics from the 2025 survey.
 composed: true
 article: true

--- a/src/pages/talks-and-events.mdx
+++ b/src/pages/talks-and-events.mdx
@@ -1,5 +1,5 @@
 ---
-title: Talks & events
+title: Talks & Keynotes on Production ML, MLOps and AI Security
 description: Keynotes, conference talks and roundtables on production ML, security, explainability and agentic systems.
 composed: true
 layout: ../layouts/ProseLayout.astro


### PR DESCRIPTION
## Summary

- apply the phase-2 intent audit titles across evergreen and principle pages
- derive unique topical newsletter issue titles from existing summaries, bounded to 65 characters
- add minimal head-only SEO title and description overrides where frontmatter also owns visible content

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run check:ratchet` (0 errors, 0 warnings, 0 hints)
- `npm run build` (439 pages)
- built HTML: no title over 65 characters, no duplicate title in the changed route set, and every OG/Twitter title mirrors the document title
- built HTML: issues 399, 200 and 5 plus evergreen pages spot-checked
- merge-base/head body markup identical across 34 affected representative routes after normalizing metadata-only Pagefind attributes and nondeterministic Astro island IDs
- CI visual parity: zero differing pixels across all 37 captured routes at 1440x1000 and 420x900, in both dark and light themes
