### PR TITLE
fix(seo): technical quick wins from the phase-1/3 audit

### DIFF
--- a/STYLES.md
+++ b/STYLES.md
@@ -202,7 +202,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 
 ## Global stylesheet
 
-`src/styles/tokens.css` is 1,319 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
+`src/styles/tokens.css` is 1,315 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
 
 | Category                             | Rules | Declarations | Contents                                                                                                                              |
 | ------------------------------------ | ----: | -----------: | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -216,7 +216,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 | Responsive foundation                |     7 |            8 | Global section, typography, primitive and form adjustments at the named breakpoints.                                                  |
 | Cross-surface and canvas integration |    73 |          151 | Canvas mount contracts, homepage section composition, shared composed-page clusters and rules spanning a page plus a child component. |
 | Theme overrides                      |     1 |          104 | Every theme-dependent token's light value on `:root[data-theme='light']`.                                                             |
-| Total                                |   257 |          701 | Global CSS only.                                                                                                                      |
+| Total                                |   256 |          699 | Global CSS only.                                                                                                                      |
 
 ## Component and page owners
 
@@ -287,7 +287,7 @@ Search by the surface name or representative selector below before adding a rule
 | `ProseLayout.astro`                                                               | Standard article prose shell                                                                           | `.prose-content`                                                               |
 | `pages/network.mdx`                                                               | Network page join introduction                                                                         | `.join-intro`                                                                  |
 | `pages/newsletter/[issue].astro`                                                  | Newsletter issue meta bar, article deck and issue navigation                                           | `newsletter-meta-bar`, `.issue-meta`, `.newsletter-page`                       |
-| `pages/newsletter/index.astro`                                                    | Newsletter archive RSS pill, latest card and issue grid                                                | `.rss-link`, `.latest-card`, `.issue-grid`                                     |
+| `pages/newsletter/index.astro`                                                    | Newsletter archive latest card and issue grid                                                          | `.latest-card`, `.issue-grid`                                                  |
 | `pages/partners.mdx`                                                              | Partners page policy feature and list heading                                                          | `.policy-feature`, `.partner-list-heading`                                     |
 | `pages/open-source/index.mdx` | Open-source project list composition | `.oss-projects` |
 | `pages/policy.mdx`                                                                | Policy page work grid composition                                                                      | `.policy-work`                                                                 |
@@ -358,4 +358,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: 5f3b3fa2df21a9c783a2501a76a79b93146f2d8a8022d9ea1312dcdb53406d85 -->
+<!-- styles-hash: b289326c851de3d7b0a620e3b1d756c4c9b7ff34cb1b36122ac7a201788612b8 -->

--- a/STYLES.md
+++ b/STYLES.md
@@ -202,7 +202,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 
 ## Global stylesheet
 
-`src/styles/tokens.css` is 1,315 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
+`src/styles/tokens.css` is 1,319 lines. The counts below are from the current parsed stylesheet: a rule is a CSS style rule or `@font-face` rule, keyframe step selectors are excluded, and declarations inside keyframes are included.
 
 | Category                             | Rules | Declarations | Contents                                                                                                                              |
 | ------------------------------------ | ----: | -----------: | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -216,7 +216,7 @@ pair is now compared by `npm run check:ratchet` rather than by memory.
 | Responsive foundation                |     7 |            8 | Global section, typography, primitive and form adjustments at the named breakpoints.                                                  |
 | Cross-surface and canvas integration |    73 |          151 | Canvas mount contracts, homepage section composition, shared composed-page clusters and rules spanning a page plus a child component. |
 | Theme overrides                      |     1 |          104 | Every theme-dependent token's light value on `:root[data-theme='light']`.                                                             |
-| Total                                |   256 |          699 | Global CSS only.                                                                                                                      |
+| Total                                |   257 |          701 | Global CSS only.                                                                                                                      |
 
 ## Component and page owners
 
@@ -358,4 +358,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: b289326c851de3d7b0a620e3b1d756c4c9b7ff34cb1b36122ac7a201788612b8 -->
+<!-- styles-hash: 63fd9caff555de006a7bbfbbf4f93bdf554af3c813853d278ed64c627776cc74 -->

--- a/TODO.md
+++ b/TODO.md
@@ -89,3 +89,7 @@ The talks page has only five `<img>` elements, all correctly lazy and none above
 Fixable without changing anything anyone sees: render the photograph as an HTML `<img>` layer behind the generated SVG rather than inside it, or gate the banner on an `IntersectionObserver`. The generated ground and motifs are cheap and can stay eager; it is only the remote photograph that is worth deferring.
 
 Explicitly NOT in scope: the reel mounts the active talk's player eagerly, which costs about 1 MB and sets two third-party cookies before any interaction. That is deliberate — it is what makes pressing play instant — and the owner has decided to keep it (2026-08-10). Do not "optimise" it away.
+
+## Reveal gate: exempt above-the-fold content from opacity-0
+
+Phase-3 CWV audit (2026-08-12, tmp/report-seo-phase3.md): the inline `[data-reveal]{opacity:0}` rule in BaseLayout.astro gates LCP on JS execution on every route — /privacy/ (ungated) renders content in ~106ms vs 1.4-1.9s elsewhere, and the h1 itself starts invisible. Fix by exempting the first viewport (or gating the rule behind a JS-added class so no-JS renders fully visible), keeping all below-fold reveal motion. Visible motion change: land alone, owner-validated with before/after per AGENTS.md. The prefers-reduced-motion branch already shows the opt-out pattern.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'astro/config';
-import { existsSync, globSync } from 'node:fs';
+import { existsSync, globSync, readFileSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 import { loadEnv } from 'vite';
 import mdx from '@astrojs/mdx';
@@ -17,6 +17,14 @@ import rehypeSectionize from './src/plugins/rehype-sectionize.mjs';
 // rendered page entirely.
 const { FORM_ENDPOINT = '' } = loadEnv(process.env.NODE_ENV ?? 'production', process.cwd(), '');
 const formToken = FORM_ENDPOINT ? Buffer.from(FORM_ENDPOINT, 'utf8').toString('base64') : '';
+const newsletterLastmod = new Map(
+  globSync('src/content/newsletter/*.md').flatMap((filename) => {
+    const date = readFileSync(filename, 'utf8').match(/^date:\s*(\d{4}-\d{2}-\d{2})\s*$/m)?.[1];
+    return date
+      ? [[`https://ethical.institute/newsletter/${basename(filename, '.md')}/`, date]]
+      : [];
+  }),
+);
 const newsletterRedirects = Object.fromEntries(
   globSync('src/content/newsletter/*.md')
     .map((filename) => basename(filename, '.md'))
@@ -82,6 +90,12 @@ export default defineConfig({
     mdx(),
     preact(),
     // Prototypes are working sketches, not pages anyone should find in search.
-    sitemap({ filter: (page) => !page.includes('/prototypes/') }),
+    sitemap({
+      filter: (page) => !page.includes('/prototypes/'),
+      serialize(item) {
+        const lastmod = newsletterLastmod.get(item.url);
+        return lastmod ? { ...item, lastmod } : item;
+      },
+    }),
   ],
 });

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -54,15 +54,18 @@ const ariaSentence = [...subtitle_lines, initialBeneficiary].filter(Boolean).joi
     }
     <h1>
       {
-        title.map((line, index) =>
-          index === 2 ? (
-            <em class="glitch" data-text={line}>
-              {line}
-            </em>
-          ) : (
-            <span>{line}</span>
-          ),
-        )
+        title.map((line, index) => (
+          <>
+            {index > 0 && ' '}
+            {index === 2 ? (
+              <em class="glitch" data-text={line}>
+                {line}
+              </em>
+            ) : (
+              <span>{line}</span>
+            )}
+          </>
+        ))
       }
     </h1>
     <type-writer data-beneficiaries={JSON.stringify(beneficiaries)}>

--- a/src/components/ProjectFeature.astro
+++ b/src/components/ProjectFeature.astro
@@ -64,7 +64,7 @@ const statline = metricStyle === 'line' ? metrics.map(({ value, label }) => (lab
         </p>
       )
     }
-    <h3 data-morph-source={morph} data-morph-name={morph}>{title}</h3>
+    <h2 data-morph-source={morph} data-morph-name={morph}>{title}</h2>
     <p>{text}</p>
     <slot name="note" />
 

--- a/src/components/ProjectFeature.css
+++ b/src/components/ProjectFeature.css
@@ -35,8 +35,8 @@
   margin: 0;
 }
 
-.oss-copy h3,
-.kaos-feature h3 {
+.oss-copy h2,
+.kaos-feature h2 {
   font: 300 38px/1.08 var(--font-display);
   margin: 16px 0 0;
 }
@@ -128,7 +128,7 @@
   padding: 44px;
 }
 
-.kaos-feature h3 {
+.kaos-feature h2 {
   font-size: 40px;
   line-height: 1.06;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,15 +11,20 @@ const { frontmatter = {} } = Astro.props;
 const title = frontmatter.title ?? 'The Institute for Ethical AI Alignment & Safety';
 const seoTitle = frontmatter.seoTitle ?? title;
 const description = frontmatter.seoDescription ?? frontmatter.description ?? metaDescription;
-const canonical = new URL(Astro.url.pathname, Astro.site);
+const canonical = new URL(frontmatter.canonicalPath ?? Astro.url.pathname, Astro.site);
 const socialImage = new URL(frontmatter.image ?? ogImage, Astro.site);
 const organization = {
   '@context': 'https://schema.org',
   '@type': 'Organization',
   name: 'The Institute for Ethical AI Alignment & Safety',
+  alternateName: 'The Institute for Ethical AI & Machine Learning',
   url: 'https://ethical.institute/',
   logo: new URL('/favicon.png', Astro.site).href,
-  sameAs: ['https://github.com/EthicalML'],
+  sameAs: [
+    'https://github.com/EthicalML',
+    'https://machinelearning.substack.com',
+    'https://www.linkedin.com/newsletters/the-machine-learning-engineer-6882216044568571904/',
+  ],
 };
 const article = frontmatter.article
   ? {
@@ -152,7 +157,7 @@ const article = frontmatter.article
         }
       }
     </style>
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=UA-89407852-2"></script>
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-L2HXV1W6H6"></script>
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -160,14 +165,14 @@ const article = frontmatter.article
         dataLayer.push(arguments);
       }
       gtag('js', new Date());
-      gtag('config', 'UA-89407852-2');
+      gtag('config', 'G-L2HXV1W6H6');
       let initialPageLoad = true;
       document.addEventListener('astro:page-load', () => {
         if (initialPageLoad) {
           initialPageLoad = false;
           return;
         }
-        gtag('config', 'UA-89407852-2', {
+        gtag('config', 'G-L2HXV1W6H6', {
           page_path: location.pathname + location.search,
           page_title: document.title,
         });

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -9,10 +9,12 @@ const { frontmatter } = Astro.props;
       <slot />
     ) : (
       <article class:list={['prose-page', frontmatter.eyebrow && 'has-outer-header']}>
-        <header class="prose-header" data-reveal>
-          <p class="eyebrow">{frontmatter.eyebrow ?? 'THE INSTITUTE'}</p>
-          <h1>{frontmatter.title}</h1>
-        </header>
+        {!frontmatter.eyebrow && (
+          <header class="prose-header" data-reveal>
+            <p class="eyebrow">THE INSTITUTE</p>
+            <h1>{frontmatter.title}</h1>
+          </header>
+        )}
         <div class="prose-content">
           <slot />
         </div>

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -9,12 +9,10 @@ const { frontmatter } = Astro.props;
       <slot />
     ) : (
       <article class:list={['prose-page', frontmatter.eyebrow && 'has-outer-header']}>
-        {!frontmatter.eyebrow && (
-          <header class="prose-header" data-reveal>
-            <p class="eyebrow">THE INSTITUTE</p>
-            <h1>{frontmatter.title}</h1>
-          </header>
-        )}
+        <header class="prose-header" data-reveal>
+          <p class="eyebrow">{frontmatter.eyebrow ?? 'THE INSTITUTE'}</p>
+          <h1>{frontmatter.title}</h1>
+        </header>
         <div class="prose-content">
           <slot />
         </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,7 +7,7 @@ const frontmatter = {
   title: 'Page not found',
   description: 'The requested page could not be found. Return to the Institute homepage or explore the current work.',
   noindex: true,
-  noCanonical: true,
+  canonicalPath: '/404.html',
 };
 ---
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -241,6 +241,16 @@ import FormSection from '../components/FormSection.astro';
 import PolicySection from '../components/PolicySection.astro';
 import { contactFormCopy, contactFormTitle, networkSectors, networkStats } from '../data/contactForm';
 
+<script
+  type="application/ld+json"
+  set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'The Institute for Ethical AI Alignment & Safety',
+    url: 'https://ethical.institute/',
+  })}
+/>
+
 <Hero {...frontmatter.hero} />
 
 <StatBand stats={frontmatter.evidence} />

--- a/src/pages/reports/state-of-ml-2024.mdx
+++ b/src/pages/reports/state-of-ml-2024.mdx
@@ -4,6 +4,7 @@ seoTitle: The State of Production ML 2024 — MLOps Practitioner Survey
 description: Practitioner-reported production machine learning practices, tools, organisational context and demographics from the 2024 survey.
 composed: true
 article: true
+datePublished: 2025-01-15
 layout: ../../layouts/ProseLayout.astro
 chapters:
   - slug: context
@@ -149,14 +150,6 @@ export const report = buildSurveyReport(survey2024Csv);
   intro="What 177 practitioners reported from production: CI/CD supported 69% of deployment workflows, AWS served more than half of cloud users, monitoring was the top challenge at 45%, and PyTorch led the library field at 36%."
 />
 
-<SurveyEvidence
-  edition={2024}
-  sample={177}
-  fieldDates="14 September 2024 to 15 January 2025"
-  methodology="This self-selected practitioner survey reports the nonblank response base for each question. Percentages use that question-level base, and totals can exceed 100% where respondents could select more than one answer. Findings describe the respondents and are not population estimates."
-  citation="The Institute for Ethical AI Alignment & Safety (2024), The State of Production ML in 2024, https://ethical.institute/reports/state-of-ml-2024/."
-/>
-
 <SurveyReport
   report={report}
   year={2024}
@@ -164,4 +157,12 @@ export const report = buildSurveyReport(survey2024Csv);
   findings={frontmatter.findings}
   stats={frontmatter.stats}
   methodology={frontmatter.methodology}
+/>
+
+<SurveyEvidence
+  edition={2024}
+  sample={177}
+  fieldDates="14 September 2024 to 15 January 2025"
+  methodology="This self-selected practitioner survey reports the nonblank response base for each question. Percentages use that question-level base, and totals can exceed 100% where respondents could select more than one answer. Findings describe the respondents and are not population estimates."
+  citation="The Institute for Ethical AI Alignment & Safety (2024), The State of Production ML in 2024, https://ethical.institute/reports/state-of-ml-2024/."
 />

--- a/src/pages/reports/state-of-ml-2025.mdx
+++ b/src/pages/reports/state-of-ml-2025.mdx
@@ -4,6 +4,7 @@ seoTitle: The State of Production ML 2025 — MLOps Practitioner Survey
 description: Practitioner-reported production machine learning practices, tools, organisational context and demographics from the 2025 survey.
 composed: true
 article: true
+datePublished: 2025-12-01
 layout: ../../layouts/ProseLayout.astro
 chapters:
   - slug: context
@@ -150,14 +151,6 @@ export const report = buildSurveyComparison(survey2025Csv, survey2024Csv);
   intro="What 135 practitioners report from production: LLM and time series work surged, monitoring remains the top challenge at 42%, PyTorch edged ahead of scikit-learn, and AI risk and governance functions doubled year on year. Every answer compares against the 2024 baseline as you move through the chapters."
 />
 
-<SurveyEvidence
-  edition={2025}
-  sample={135}
-  fieldDates="31 August to 1 December 2025"
-  methodology="This self-selected practitioner survey reports the nonblank response base for each question. Percentages use that question-level base, and totals can exceed 100% where respondents could select more than one answer. Findings describe the respondents and are not population estimates."
-  citation="The Institute for Ethical AI Alignment & Safety (2025), The State of Production ML in 2025, https://ethical.institute/reports/state-of-ml-2025/."
-/>
-
 <SurveyReport
   report={report}
   year={2025}
@@ -165,4 +158,12 @@ export const report = buildSurveyComparison(survey2025Csv, survey2024Csv);
   findings={frontmatter.findings}
   stats={frontmatter.stats}
   methodology={frontmatter.methodology}
+/>
+
+<SurveyEvidence
+  edition={2025}
+  sample={135}
+  fieldDates="31 August to 1 December 2025"
+  methodology="This self-selected practitioner survey reports the nonblank response base for each question. Percentages use that question-level base, and totals can exceed 100% where respondents could select more than one answer. Findings describe the respondents and are not population estimates."
+  citation="The Institute for Ethical AI Alignment & Safety (2025), The State of Production ML in 2025, https://ethical.institute/reports/state-of-ml-2025/."
 />


### PR DESCRIPTION
## Summary

- correct hero text spacing and open-source heading hierarchy, and give the 404 page its exact canonical
- keep GA4 while removing the dead UA path, add dated newsletter sitemap entries, and improve WebSite/Organization/report structured data
- move each report citation panel below its findings and record the separate reveal-gate follow-up
- drop the `/reports/` duplicate-h1 fix after merge-base parity showed an additional desktop visual change outside the allowed scope

The shared Article JSON-LD generator was not changed. Report dates are the documented field-end dates because no separate publication record was derivable: 2025-01-15 for the 2024 report and 2025-12-01 for the 2025 report.

The homepage emits WebSite schema without SearchAction because Pagefind is a modal and exposes no crawlable results URL pattern. The GitHub, Substack, and LinkedIn Organization properties were each verified live on 2026-08-12.

## Verification

- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run check:ratchet`
- `npm run check` (147 files, zero diagnostics)
- `npm run build` (439 indexed pages)
- build-output audit: 434 sitemap URLs, 399 newsletter-only `lastmod` values, zero evergreen `lastmod` values
- build-output audit across 1,261 HTML files: zero `UA-89407852-2` and `analytics.js` references; GA4 present on all 439 real pages
- build-output DOM audit: corrected h1 text on `/`, `/newsletter/396/`, `/network/`; all five `/open-source/` project headings are h2
- schema audit: exact `/404.html` canonical and `og:url`; WebSite and expanded Organization data; both report `datePublished` values
- ordering audit: SurveyReport precedes SurveyEvidence on both report routes
- CI: lint, typecheck, build, motion, and dark/light merge-base visual sweeps green

## Visual evidence

The local Playwright DOM/screenshot/parity gates were attempted, but this managed macOS sandbox denies Chromium its Mach rendezvous port; Firefox is also aborted by the host, so local before/after screenshots could not be captured.

Before applying `visual-change`, the CI merge-base sweep photographed 37 routes in both themes and at 1440x1000 and 420x900. `/`, `/newsletter/396/`, `/network/`, and `/open-source/` had zero differing pixels. Only the two report routes moved at both viewports from the intended citation relocation. The first sweep also identified `/reports/` at desktop; that item was then reverted under the brief fail-fast rule. The dark/light parity comments on this PR retain the exact route counts and pixel deltas.