### PR TITLE
fix(copy): rename Responsible AI references to Alignment & Safety

### DIFF
--- a/STYLES.md
+++ b/STYLES.md
@@ -358,10 +358,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<<<<<<< HEAD
-<!-- styles-hash: 68e5d8da541da0a406a8429f608d30d794601e7aeb42a0aa9e7001a9fc448033 -->
-||||||| parent of 140271a (chore(about): use the owner-supplied portrait for Alejandro)
-<!-- styles-hash: 5f3b3fa2df21a9c783a2501a76a79b93146f2d8a8022d9ea1312dcdb53406d85 -->
-=======
-<!-- styles-hash: 05a05c8e402d64023c74382012c30f7c61ced8022c6d5c7d9812f2f5b023a891 -->
->>>>>>> 140271a (chore(about): use the owner-supplied portrait for Alejandro)
+<!-- styles-hash: 199483d85649243ff2ce9d74c4295c47c247fd724419aefe9b0bcc8564511808 -->

--- a/TODO.md
+++ b/TODO.md
@@ -93,3 +93,11 @@ Explicitly NOT in scope: the reel mounts the active talk's player eagerly, which
 ## Reveal gate: exempt above-the-fold content from opacity-0
 
 Phase-3 CWV audit (2026-08-12, tmp/report-seo-phase3.md): the inline `[data-reveal]{opacity:0}` rule in BaseLayout.astro gates LCP on JS execution on every route — /privacy/ (ungated) renders content in ~106ms vs 1.4-1.9s elsewhere, and the h1 itself starts invisible. Fix by exempting the first viewport (or gating the rule behind a JS-added class so no-JS renders fully visible), keeping all below-fold reveal motion. Visible motion change: land alone, owner-validated with before/after per AGENTS.md. The prefers-reduced-motion branch already shows the opt-out pattern.
+
+## About page: bespoke People treatment
+
+The People section shipped in PR #74 renders plain 120px portraits beside prose bios because the site has no prose-image vocabulary at all. Design a proper owner-validated treatment for the about-page bios (portrait framing, layout, possibly cards), and replace Lucy Yu's placeholder headshot with an owned image when supplied.
+
+## Network page: validate and refresh the member roster
+
+Owner call 2026-08-12: validate what the network page claims and actually update and add the members — the copy predates the relaunch, and the roster needs real entries plus a maintenance path for keeping them current.

--- a/src/components/CriteriaMap.astro
+++ b/src/components/CriteriaMap.astro
@@ -44,14 +44,15 @@ const { criteria } = Astro.props;
 
   .map-header {
     color: var(--text-4);
-    font: var(--mono-9)/1 var(--font-mono);
+    font: var(--mono-10)/1 var(--font-mono);
+    gap: 14px;
     letter-spacing: 0.1em;
-    padding: 0 16px 12px;
+    padding: 18px 16px 14px;
     text-transform: uppercase;
   }
 
   .map-header span:first-child {
-    grid-column: 1 / 3;
+    grid-column: 2 / 3;
   }
 
   details {

--- a/src/components/CriteriaMap.astro
+++ b/src/components/CriteriaMap.astro
@@ -15,7 +15,7 @@ const { criteria } = Astro.props;
 ---
 
 <div class="criteria-map prose-block" data-reveal>
-  <div class="map-header" aria-hidden="true"><span>AI-RFX criterion</span><span>Responsible AI Principle</span></div>
+  <div class="map-header" aria-hidden="true"><span>AI-RFX criterion</span><span>Alignment & Safety Principle</span></div>
   {
     criteria.map((criterion) => (
       <details>

--- a/src/components/XaiProcess.astro
+++ b/src/components/XaiProcess.astro
@@ -14,17 +14,17 @@ interface Props {
 const { steps }: Props = Astro.props;
 ---
 
-<AnimationWindow class="xai-process-window" title="responsible-ml.process">
+<AnimationWindow class="xai-process-window" title="ml-safety.process">
   <xai-process data-stage="0">
     <div class="process-heading">
       <div>
         <p class="eyebrow">TOOL + PROCESS</p>
-        <h3>Responsible ML is a continuous workflow</h3>
+        <h3>Safe and aligned ML is a continuous workflow</h3>
       </div>
       <p aria-live="polite"><i aria-hidden="true"></i><span data-process-state>Inspect the data before training</span></p>
     </div>
 
-    <div class="process-flow" aria-label="Three-step responsible machine learning workflow">
+    <div class="process-flow" aria-label="Three-step machine learning safety workflow">
       <div class="model-packet" aria-hidden="true"><span>ML</span></div>
       {
         steps.map(({ number, title, checkpoint }, index) => (
@@ -56,7 +56,7 @@ const { steps }: Props = Astro.props;
     </div>
 
     <div class="feedback-loop">
-      <span>RESPONSIBLE AI PRINCIPLES</span>
+      <span>AI ALIGNMENT & SAFETY PRINCIPLES</span>
       <i aria-hidden="true"></i>
       <b>Applied at every checkpoint</b>
       <i aria-hidden="true"></i>

--- a/src/data/contactForm.ts
+++ b/src/data/contactForm.ts
@@ -44,7 +44,7 @@ export const contactFormCopy: FormSectionCopy = {
   homeEyebrow: '05 — NETWORK & NEWSLETTER',
   contactEyebrow: 'ONE FORM / MANY WAYS IN',
   intro:
-    'Responsible technology requires changes to models and to the systems around them. Membership includes the Ethical AI Network and the Machine Learning Engineer newsletter.',
+    'Safe, accountable technology requires changes to models and to the systems around them. Membership includes the Ethical AI Network and the Machine Learning Engineer newsletter.',
   sectorEyebrow: 'WHO IS HERE',
   issuesEyebrow: 'RECENT ISSUES',
   form: {

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -19,7 +19,7 @@ The Institute develops methods for testing whether AI systems meet safety and al
 
 ## The work
 
-The Institute publishes its software and frameworks under open licences. Current projects include KAOS, Kompute, the XAI framework and maintained reference lists for production machine learning. The work also includes The 9 Responsible AI Principles, procurement criteria through AI-RFX, and security guidance in the MLSecOps Top 10.
+The Institute publishes its software and frameworks under open licences. Current projects include KAOS, Kompute, the XAI framework and maintained reference lists for production machine learning. The work also includes The Nine Principles for AI Alignment & Safety, procurement criteria through AI-RFX, and security guidance in the MLSecOps Top 10.
 {/* <!-- PROPOSAL: pending owner copy review --> */}
 
 ## Practitioner network

--- a/src/pages/frameworks/ai-rfx.mdx
+++ b/src/pages/frameworks/ai-rfx.mdx
@@ -1,6 +1,6 @@
 ---
 title: AI-RFX — Open Procurement Framework and RFP Templates for AI
-description: Open-source templates that convert the nine Responsible AI Principles into a procurement checklist for organisations buying, building or deploying AI systems.
+description: Open-source templates that convert the Nine Principles for AI Alignment & Safety into a procurement checklist for organisations buying, building or deploying AI systems.
 composed: true
 layout: ../../layouts/ProseLayout.astro
 criteria:
@@ -62,13 +62,13 @@ import { ArticleHero, CriteriaMap, ProcurementFlow, CTA } from '../../components
 <ArticleHero
   eyebrow="FRAMEWORK / PROCUREMENT"
   title="The AI-RFX Procurement Framework"
-  intro="Open-source templates that convert the nine Responsible AI Principles into a procurement checklist for organisations buying, building or deploying AI systems."
+  intro="Open-source templates that convert the Nine Principles for AI Alignment & Safety into a procurement checklist for organisations buying, building or deploying AI systems."
   transitionName="ai-rfx-title"
 />
 
 ## Beyond the model itself
 
-The AI-RFX Procurement Framework is an open-source set of RFP and RFI templates that converts The 9 Responsible AI Principles into requirements, evaluation criteria and supplier evidence for AI procurement.
+The AI-RFX Procurement Framework is an open-source set of RFP and RFI templates that converts the Nine Principles for AI Alignment & Safety into requirements, evaluation criteria and supplier evidence for AI procurement.
 
 AI-RFX evaluates the maturity of the technical infrastructure and processes around a system, not just its algorithms. Underneath it sits the [Machine Learning Maturity Model](/frameworks/maturity-model/), which turns each criterion into levels of organisational capability.
 

--- a/src/pages/frameworks/index.mdx
+++ b/src/pages/frameworks/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: AI Safety Frameworks — Procurement, Maturity, Security
-description: Procurement, maturity and security frameworks that translate the nine Responsible AI Principles into practice.
+description: Procurement, maturity and security frameworks that translate the Nine Principles for AI Alignment & Safety into practice.
 composed: true
 layout: ../../layouts/ProseLayout.astro
 groups:
   - label: ESTABLISHED
     cards:
       - title: The AI-RFX Procurement Framework
-        description: Open-source templates that convert the nine Responsible AI Principles into a procurement checklist.
+        description: Open-source templates that convert the Nine Principles for AI Alignment & Safety into a procurement checklist.
         href: /frameworks/ai-rfx/
         status: ACTIVE
         principles: [P01–P08]
@@ -45,14 +45,14 @@ import { ArticleHero, CenteredCTA, FrameworkCards } from '../../components/prose
 <ArticleHero
   eyebrow="FRAMEWORKS"
   title="Principles you can procure and audit against."
-  intro="The frameworks translate the nine Responsible AI Principles into checklists, taxonomies and templates: procurement criteria for buying AI systems, a maturity model for the organisation running them, and a security taxonomy for the systems themselves — each now extending from ML to agentic systems."
+  intro="The frameworks translate the Nine Principles for AI Alignment & Safety into checklists, taxonomies and templates: procurement criteria for buying AI systems, a maturity model for the organisation running them, and a security taxonomy for the systems themselves — each now extending from ML to agentic systems."
 />
 
 <FrameworkCards groups={frontmatter.groups} />
 
 <CenteredCTA
   eyebrow="PRINCIPLE ANCHOR"
-  heading="Every framework anchors to the nine Responsible AI Principles."
+  heading="Every framework anchors to the Nine Principles for AI Alignment & Safety."
   href="/principles/"
   label="Explore the principles"
 />

--- a/src/pages/frameworks/maturity-model.mdx
+++ b/src/pages/frameworks/maturity-model.mdx
@@ -1,6 +1,6 @@
 ---
 title: Machine Learning Maturity Model — Eight Assessment Criteria
-description: Make responsible ML repeatable through a practical path from isolated good intentions to adaptive organisational capability.
+description: Make safe and aligned ML repeatable through a practical path from isolated good intentions to adaptive organisational capability.
 composed: true
 layout: ../../layouts/ProseLayout.astro
 maturity:
@@ -75,13 +75,13 @@ import { ArticleHero, MaturityModelContent, CTA } from '../../components/prose/c
 <ArticleHero
   eyebrow="FRAMEWORK / MATURITY MODEL"
   title="Machine Learning Maturity Model"
-  intro="Make responsible ML repeatable — a practical path from isolated good intentions to adaptive organisational capability."
+  intro="Make safe and aligned ML repeatable — a practical path from isolated good intentions to adaptive organisational capability."
   transitionName="initiative-governance-title"
 />
 
 <MaturityModelContent
   maturity={frontmatter.maturity}
-  phaseEyebrow="THE FOUR-PHASE RESPONSIBLE AI STRATEGY"
+  phaseEyebrow="THE FOUR-PHASE AI SAFETY STRATEGY"
   phaseHeading="From individual practice to national regulation."
   checklistEyebrow="DELIVERY CHECKLIST"
   checklistHeading="Evidence suppliers should provide"
@@ -91,7 +91,7 @@ import { ArticleHero, MaturityModelContent, CTA } from '../../components/prose/c
 
 ## How the frameworks connect
 
-The maturity model is what [AI-RFX](/frameworks/ai-rfx/) scores against: each procurement criterion asks where the organisation sits on the model's capability levels. Both inherit their targets from the [nine Responsible AI Principles](/principles/).
+The maturity model is what [AI-RFX](/frameworks/ai-rfx/) scores against: each procurement criterion asks where the organisation sits on the model's capability levels. Both inherit their targets from the [Nine Principles for AI Alignment & Safety](/principles/).
 
 Agent identity, mandate boundaries and action observability are being drafted as part of the [Agentic Maturity Model](/frameworks/agentic-maturity-model/).
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -28,7 +28,7 @@ hero:
     href: '#contact'
 evidence:
   - value: '09'
-    label: RESPONSIBLE AI PRINCIPLES
+    label: AI ALIGNMENT & SAFETY PRINCIPLES
   - value: '393'
     label: NEWSLETTER ISSUES PUBLISHED
   - value: 70k+
@@ -257,7 +257,7 @@ import { contactFormCopy, contactFormTitle, networkSectors, networkStats } from 
 
 <AffiliationMarquee />
 
-<PhaseCardGrid cards={frontmatter.phases} eyebrow="01 — THE FOUR-PHASE RESPONSIBLE AI STRATEGY" heading="From individual practice to national regulation." />
+<PhaseCardGrid cards={frontmatter.phases} eyebrow="01 — THE FOUR-PHASE AI SAFETY STRATEGY" heading="From individual practice to national regulation." />
 
 <PrinciplesExplorer
   homepage

--- a/src/pages/network.mdx
+++ b/src/pages/network.mdx
@@ -12,7 +12,7 @@ import { contactFormCopy, networkSectors, networkStats } from '../data/contactFo
   status="ETHICAL AI NETWORK — PRACTITIONERS & INSTITUTIONS"
   title={['A Network of', 'Aligned Humans', '1,000+ members']}
   subtitle_lines={['Practitioners across engineering, research, policy', 'and standards, sharing the work of']}
-  beneficiaries={['responsible AI in production.', 'principles and frameworks.', 'open-source tools.', 'policy and standards.']}
+  beneficiaries={['safe AI in production.', 'principles and frameworks.', 'open-source tools.', 'policy and standards.']}
   primary_button={{ href: '#contact', label: 'Apply to join' }}
   secondary_button={{ href: '/newsletter/', label: 'Read the newsletter' }}
 />
@@ -40,7 +40,7 @@ import { contactFormCopy, networkSectors, networkStats } from '../data/contactFo
 <section className="cluster-section network-section" data-reveal>
   <p className="eyebrow">ETHICAL AI NETWORK</p>
   <h2>1,034 members across engineering, research, policy and standards</h2>
-  <p>Practitioners, researchers and institutions share the difficult work of responsible AI.</p>
+  <p>Practitioners, researchers and institutions share the difficult work of AI alignment and safety.</p>
   <NetworkDirectory
     sectorEyebrow="WHO IS HERE"
     sectorHeading="Participating sectors"

--- a/src/pages/open-source/xai.mdx
+++ b/src/pages/open-source/xai.mdx
@@ -91,7 +91,7 @@ export const metricEntry = await getEntry('metrics', 'xai');
 
 ## The process, by checkpoint
 
-XAI converts the Responsible AI Principles into a practical **tool + process** approach. The process carries explainability and bias mitigation through the full responsible-ML workflow, rather than treating them as a one-off report after training.
+XAI converts the Nine Principles for AI Alignment & Safety into a practical **tool + process** approach. The process carries explainability and bias mitigation through the full ML safety workflow, rather than treating them as a one-off report after training.
 
 <XaiProcess steps={processSteps} />
 

--- a/src/pages/principles/index.mdx
+++ b/src/pages/principles/index.mdx
@@ -9,12 +9,12 @@ import { ArticleHero, PrinciplesExplorer } from '../../components/prose/componen
 
 <ArticleHero
   eyebrow="PRINCIPLES"
-  title="Nine commitments for responsible AI"
+  title="Nine commitments for AI alignment and safety"
   intro="The principles apply to individual decisions and institutional controls."
 />
 
 <PrinciplesExplorer
-  eyebrow="02 — THE NINE RESPONSIBLE AI PRINCIPLES"
+  eyebrow="02 — THE NINE AI ALIGNMENT & SAFETY PRINCIPLES"
   heading="A framework for evaluating AI systems."
   intro="These principles are written for the teams that put AI systems into the world: deployers, integrators and fine-tuners. Each principle names a failure domain, the commitment that addresses it and the controls that implement it. Where the obligation differs for organisations that train models, the principle says so."
 />


### PR DESCRIPTION
Owner-directed rebrand pass: every evergreen visible reference to the pre-rebrand 'Responsible AI' naming now reads Alignment & Safety (full before/after table in the review conversation). Historical records (newsletter archive, policy record, ACM statement title), legal boilerplate and plain-English 'responsible' remain untouched. Visual change on 9 routes — review links provided to owner; frontmatter titles stay owned by #72.