### PR TITLE
feat(seo): complete the Article metadata in BaseLayout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ Owner review 2026-08-12: most page heroes are boring, especially the ones with n
 
 ## Blog landing redesign
 
-The archive shipped with an interim showcase (2026-08-13): flagship hero, featured latest card, and a ScrollStage sweep where each post's featured image fills the container behind a right-aligned translucent card column (70% dim, 80px edge fade, talks-reel spacing). Owner verdict: acceptable to ship, not yet good. Revisit properly alongside the hero family programme: explored and rejected so far are a boxed split layout, a mid-screen gradient with backdrop blur, and per-card floating fade boxes; candidate directions include per-post canvas scenes, tag filter chips, and a series shelf. Design with owner in the loop from mockups, not iterations on the live page.
+The archive shipped with an interim showcase (2026-08-13): flagship hero, featured latest card, and a ScrollStage sweep where each post's featured image fills the container behind a right-aligned translucent card column (70% dim, 80px edge fade, talks-reel spacing). Owner verdict: acceptable to ship, not yet good. Revisit properly alongside the hero family programme: explored and rejected so far are a boxed split layout, a mid-screen gradient with backdrop blur, and per-card floating fade boxes; candidate directions include per-post canvas scenes, tag filter chips, and a series shelf. Design with owner in the loop from mockups, not iterations on the live page. Batch into the next visual pass (SEO session finding 2026-08-14): the two mono-9 labels in `pages/blog/[slug].astro` (series-nav and related eyebrow) predate the owner's mono-10 ruling on the AI-RFX criteria table and should be bumped with owner review.
 
 ## Blog follow-up: proactive weekly content proposals
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import { ClientRouter } from 'astro:transitions';
 import SiteHeader from '../components/SiteHeader.astro';
 import FootnoteBand from '../components/FootnoteBand.astro';
 import { siteTitle } from '../data/navigation';
+import { authors } from '../data/authors';
 
 const metaDescription = 'An independent research institute working to ensure that frontier AI is safe, aligned and accountable to people and society.';
 const ogImage = '/images/banner.jpg';
@@ -29,22 +30,38 @@ const organization = {
     'https://www.linkedin.com/newsletters/the-machine-learning-engineer-6882216044568571904/',
   ],
 };
+// Named authors resolve through src/data/authors.ts so Person entities carry
+// url and sameAs (the E-E-A-T record); unknown names fall back to name-only.
+const person = (name: string) => {
+  const record = authors[name];
+  return record ? { '@type': 'Person', name, url: new URL(record.aboutAnchor, Astro.site).href, sameAs: record.sameAs } : { '@type': 'Person', name };
+};
 const article = frontmatter.article
   ? {
       '@context': 'https://schema.org',
       '@type': 'Article',
       headline: frontmatter.articleHeadline ?? title,
+      description,
+      url: canonical.href,
+      mainEntityOfPage: { '@type': 'WebPage', '@id': canonical.href },
+      image: socialImage.href,
       ...(frontmatter.datePublished ? { datePublished: frontmatter.datePublished } : {}),
       ...(frontmatter.sameAs?.length ? { sameAs: frontmatter.sameAs } : {}),
       author: frontmatter.articleAuthors?.length
         ? frontmatter.articleAuthors.length === 1
-          ? { '@type': 'Person', name: frontmatter.articleAuthors[0] }
-          : frontmatter.articleAuthors.map((name: string) => ({ '@type': 'Person', name }))
+          ? person(frontmatter.articleAuthors[0])
+          : frontmatter.articleAuthors.map(person)
         : {
             '@type': 'Organization',
             name: organization.name,
             url: organization.url,
           },
+      publisher: {
+        '@type': 'Organization',
+        name: organization.name,
+        url: organization.url,
+        logo: { '@type': 'ImageObject', url: organization.logo },
+      },
     }
   : undefined;
 ---
@@ -61,7 +78,9 @@ const article = frontmatter.article
     <link rel="alternate" type="application/rss+xml" title="The ML Engineer newsletter" href="/newsletter/rss.xml" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/favicon.png" type="image/png" />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={frontmatter.article ? 'article' : 'website'} />
+    {frontmatter.article && frontmatter.datePublished && <meta property="article:published_time" content={frontmatter.datePublished} />}
+    {frontmatter.article && frontmatter.articleTags?.map((tag: string) => <meta property="article:tag" content={tag} />)}
     <meta property="og:site_name" content="The Institute for Ethical AI Alignment & Safety" />
     <meta property="og:title" content={seoTitle} />
     <meta property="og:description" content={description} />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -60,6 +60,7 @@ const frontmatter = {
   article: true,
   articleHeadline: entry.data.title,
   articleAuthors: entry.data.authors,
+  articleTags: entry.data.tags,
   datePublished: publishedDate?.toISOString().slice(0, 10),
 };
 // Same dd/mm/yy chip format as the newsletter issue meta bar.

--- a/src/pages/newsletter/[issue].astro
+++ b/src/pages/newsletter/[issue].astro
@@ -56,6 +56,8 @@ const frontmatter = {
   ),
   article: true,
   articleHeadline: `The Machine Learning Engineer Issue #${issue}`,
+  articleAuthors: [author.name],
+  articleTags: entry.data.tags,
   datePublished: entry.data.date?.toISOString().slice(0, 10),
   sameAs: entry.data.syndication?.map(({ url }) => url),
 };


### PR DESCRIPTION
Takes item 1 of the SEO session's post-merge review (coordinating here so only one session lands it — this closes the deferred 'Article.author → Person wiring' item):

- **Person resolution**: `articleAuthors` names resolve through `src/data/authors.ts`; Person entities now carry `url` + `sameAs`. Newsletter issues pass their author too, so all 399 issues get it alongside the blog.
- **og:type=article** on article pages plus `article:published_time` / `article:tag` (audit H2).
- **Article block completed** with `description`, `url`, `mainEntityOfPage`, `image`, `publisher` (audit H3).

Head-only change — zero pixels moved; verified against built output on blog, newsletter and homepage route types. Item 2 (mono-9 labels) is recorded in TODO.md for the next owner-reviewed visual pass.