### PR TITLE
feat(blog): add the blog RSS feed

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -76,6 +76,7 @@ const article = frontmatter.article
     {frontmatter.noindex && <meta name="robots" content="noindex" />}
     {!frontmatter.noCanonical && <link rel="canonical" href={canonical} />}
     <link rel="alternate" type="application/rss+xml" title="The ML Engineer newsletter" href="/newsletter/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title="Production ML, responsible AI and alignment blog" href="/blog/rss.xml" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/favicon.png" type="image/png" />
     <meta property="og:type" content={frontmatter.article ? 'article' : 'website'} />

--- a/src/pages/blog/rss.xml.ts
+++ b/src/pages/blog/rss.xml.ts
@@ -1,0 +1,42 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+import { blogHref, publishedBlogEntries } from '../../utils/blog';
+
+// Preserve headroom under the 8 MB reader ceiling as new posts are added.
+const wholeTextPostLimit = 100;
+
+const absolutiseReferences = (html: string, site: URL) =>
+  html.replace(
+    /\b(href|src)=(['"])(?![a-z][a-z\d+.-]*:|#)([^'"]*)\2/gi,
+    (_match, attribute, quote, reference) => {
+      // Feed readers do not share the site's base URL, so root-relative post links
+      // need a canonical origin in the portable HTML payload.
+      return `${attribute}=${quote}${new URL(reference, site).href}${quote}`;
+    },
+  );
+
+export async function GET(context: APIContext) {
+  const site = context.site!;
+  const posts = publishedBlogEntries(await getCollection('blog')).sort(
+    (first, second) => second.data.date!.getTime() - first.data.date!.getTime(),
+  );
+
+  return rss({
+    title: 'Production ML, responsible AI and alignment blog',
+    description:
+      'Writing from The Institute for Ethical AI Alignment & Safety on production machine learning, responsible AI and AI safety.',
+    site,
+    items: posts.map((entry, index) => ({
+      title: entry.data.title,
+      link: blogHref(entry),
+      pubDate: entry.data.date!,
+      description: entry.data.summary,
+      categories: entry.data.tags,
+      ...(index < wholeTextPostLimit
+        ? { content: absolutiseReferences(entry.rendered!.html, site) }
+        : {}),
+    })),
+    customData: '<language>en</language>',
+  });
+}


### PR DESCRIPTION
## Summary

- add `/blog/rss.xml` from `publishedBlogEntries`, sorted newest first
- mirror the newsletter feed item shape, portable full-body HTML handling, and 100-item reader-size ceiling
- advertise the blog feed site-wide beside the newsletter feed in `BaseLayout`
- leave all visible RSS affordances unchanged

## Feed decisions

- drafts and scheduled previews are excluded by consuming only `publishedBlogEntries`, never the raw collection
- item links use `blogHref`; publication dates use `date`; descriptions use `summary`; tags become RSS categories
- the newest 100 posts carry rendered body HTML with relative `href` and `src` references canonicalised against the site URL

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run check:ratchet` (0 errors, warnings, hints)
- clean-cache `npm run build` after removing `.astro` and `node_modules/.astro`
- `xmllint --noout dist/blog/rss.xml`
- built feed grep: 10 `<item>` and 10 `<content:encoded>` elements, matching the 10 currently published posts
- built feed grep: 10 canonical blog item links and no root-relative body references
- `npm run verify:dom -- /blog/ --viewport 1440x1000` against this worktree preview