### PR TITLE
feat(newsletter): backlink every issue's events block to talks-and-events

### DIFF
--- a/.claude/skills/newsletter-issue/SKILL.md
+++ b/.claude/skills/newsletter-issue/SKILL.md
@@ -106,6 +106,12 @@ The weekly list mirrors the five headings and inverts their link convention: hea
 
 Check the events list against the new issue date and drop anything that has already happened. The scaffold copies it forward blind.
 
+Keep the `/talks-and-events/` backlink paragraph that sits under the events lede; every issue carries it so a reader who lands on an issue through search can reach the talks and events page. The scaffold carries it forward with the rest of the events block, so this is a check rather than an edit:
+
+```
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+```
+
 ## 6. Write the frontmatter
 
 `summary`: the five headings verbatim, comma-joined, plus ` + more 🚀`. Shorten a heading only if it is genuinely too long.

--- a/src/content/newsletter/10.md
+++ b/src/content/newsletter/10.md
@@ -85,6 +85,8 @@ We showcase Machine Learning Engineering jobs (primarily in London for now) to h
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [Machine Learning Prague](https://www.mlprague.com) [22/02/2019] - A practical conference on machine learning & DL in Prague, CZ.

--- a/src/content/newsletter/11.md
+++ b/src/content/newsletter/11.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/12.md
+++ b/src/content/newsletter/12.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/13.md
+++ b/src/content/newsletter/13.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/14.md
+++ b/src/content/newsletter/14.md
@@ -61,6 +61,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/15.md
+++ b/src/content/newsletter/15.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/16.md
+++ b/src/content/newsletter/16.md
@@ -66,6 +66,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/17.md
+++ b/src/content/newsletter/17.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/179.md
+++ b/src/content/newsletter/179.md
@@ -52,6 +52,8 @@ This article provides some interesting insights on the core concepts behind the 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyCon Italy](https://pycon.it/en) - June 2nd-5th @ Florence [[ML Security](https://pycon.it/en/talk/secure-ml-automated-best-practices-in-data-science?day=2022-06-04)]

--- a/src/content/newsletter/18.md
+++ b/src/content/newsletter/18.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/180.md
+++ b/src/content/newsletter/180.md
@@ -52,6 +52,8 @@ Recommender systems are fundamental to major internet companies. This resource i
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyCon Italy](https://pycon.it/en) - June 2nd-5th @ Florence [[ML Security](https://pycon.it/en/talk/secure-ml-automated-best-practices-in-data-science?day=2022-06-04)]

--- a/src/content/newsletter/181.md
+++ b/src/content/newsletter/181.md
@@ -52,6 +52,8 @@ Data science is not just a science, and more often than not storytelling is key.
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyCon Italy](https://pycon.it/en) - June 2nd-5th @ Florence [[ML Security](https://pycon.it/en/talk/secure-ml-automated-best-practices-in-data-science?day=2022-06-04)]

--- a/src/content/newsletter/182.md
+++ b/src/content/newsletter/182.md
@@ -52,6 +52,8 @@ The topic of developer productivity is a growing field being explored, with ofte
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [ODSC Europe](https://odsc.com/europe/) - June 15th-17th @ London [AI Ethics]

--- a/src/content/newsletter/183.md
+++ b/src/content/newsletter/183.md
@@ -52,6 +52,8 @@ To combat the prevalence of malware in the open source ecosystem, GitHub now pub
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData London](https://pydata.org/london2022/) - June 17th-19th @ London [[ML Acceleration](https://london2022.pydata.org/cfp/talk/FFAJRB/)]

--- a/src/content/newsletter/184.md
+++ b/src/content/newsletter/184.md
@@ -52,6 +52,8 @@ Every year the stackoverflow team releases their annual developer survey, this y
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData London](https://pydata.org/london2022/) - June 17th-19th @ London [[ML Acceleration](https://london2022.pydata.org/cfp/talk/FFAJRB/)]

--- a/src/content/newsletter/185.md
+++ b/src/content/newsletter/185.md
@@ -50,6 +50,8 @@ These reverse tech interview tips for interviewees are essential; there are exte
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData London](https://pydata.org/london2022/) - June 17th-19th @ London [[ML Acceleration](https://london2022.pydata.org/cfp/talk/FFAJRB/)]

--- a/src/content/newsletter/186.md
+++ b/src/content/newsletter/186.md
@@ -52,6 +52,8 @@ Chaos monkey is the codename for the service that Netflix once published showcas
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData London](https://pydata.org/london2022/) - June 17th-19th @ London [[ML Acceleration](https://london2022.pydata.org/cfp/talk/FFAJRB/)]

--- a/src/content/newsletter/187.md
+++ b/src/content/newsletter/187.md
@@ -52,6 +52,8 @@ A/B testing is key in production machine learning systems. This article provides
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData London](https://pydata.org/london2022/) - June 17th-19th @ London [[ML Acceleration](https://london2022.pydata.org/cfp/talk/FFAJRB/)]

--- a/src/content/newsletter/188.md
+++ b/src/content/newsletter/188.md
@@ -52,6 +52,8 @@ Large language models such as the more recent text-to-image DALL-E model suggest
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [Industry-strength DALL-E]

--- a/src/content/newsletter/189.md
+++ b/src/content/newsletter/189.md
@@ -52,6 +52,8 @@ Building a robust understanding on statistical foundations can be key for machin
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [Industry-strength DALL-E]

--- a/src/content/newsletter/19.md
+++ b/src/content/newsletter/19.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/190.md
+++ b/src/content/newsletter/190.md
@@ -52,6 +52,8 @@ Containers continue to become ubiquitous in the general software and data scienc
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/191.md
+++ b/src/content/newsletter/191.md
@@ -52,6 +52,8 @@ The SciPy 2022 conference videos are out now avilable for free. This year's even
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/192.md
+++ b/src/content/newsletter/192.md
@@ -52,6 +52,8 @@ Data visualisation with languages like python provide a fantastic resource for b
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/193.md
+++ b/src/content/newsletter/193.md
@@ -52,6 +52,8 @@ In order to have a comprehensive data protection and privacy policy, organizatio
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/194.md
+++ b/src/content/newsletter/194.md
@@ -50,6 +50,8 @@ Sometimes you just want to know how fast your code can go, without benchmarking 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/195.md
+++ b/src/content/newsletter/195.md
@@ -52,6 +52,8 @@ PapersWithCode is a fantastic initiative that advocates for reproducible researc
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/196.md
+++ b/src/content/newsletter/196.md
@@ -50,6 +50,8 @@ Awful AI is a curated list to track current scary usages of AI. It consists of a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/197.md
+++ b/src/content/newsletter/197.md
@@ -52,6 +52,8 @@ Energy consumption has become growingly important due to growing climate concern
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/198.md
+++ b/src/content/newsletter/198.md
@@ -52,6 +52,8 @@ Vector databases and vector search are on the radar of a growing number of techn
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [EuroSciPy](https://pydata.org/london2022/) - August 29th @ Basel [[Industry-strength DALL-E](https://pretalx.com/euroscipy-2022/talk/89WNRG/)]

--- a/src/content/newsletter/199.md
+++ b/src/content/newsletter/199.md
@@ -52,6 +52,8 @@ Matrix multiplication is the most used mathematical operation in all of science 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [Kubecon NA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - 24th-28th October @ Detroit

--- a/src/content/newsletter/20.md
+++ b/src/content/newsletter/20.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [DataFest19](https://www.datafest.global/) [11/03/2019] - Two week festival of Data Innovation hosted across Scotland, UK.

--- a/src/content/newsletter/200.md
+++ b/src/content/newsletter/200.md
@@ -61,6 +61,8 @@ OpenAI introduces an exciting new initiative through the codename "Whisper", a n
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [Kubecon NA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - 24th-28th October @ Detroit

--- a/src/content/newsletter/201.md
+++ b/src/content/newsletter/201.md
@@ -63,6 +63,8 @@ As organisations adopt data-driven decision making through robust and scalable i
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [Kubecon NA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - 24th-28th October @ Detroit

--- a/src/content/newsletter/202.md
+++ b/src/content/newsletter/202.md
@@ -52,6 +52,8 @@ In data science and data engineering the mentality is shifting from data project
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [Kubecon NA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - 24th-28th October @ Detroit

--- a/src/content/newsletter/203.md
+++ b/src/content/newsletter/203.md
@@ -50,6 +50,8 @@ Reviewing mathematical foundations is key for both computer science and machine 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [Kubecon NA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) - 24th-28th October @ Detroit

--- a/src/content/newsletter/204.md
+++ b/src/content/newsletter/204.md
@@ -52,6 +52,8 @@ Streaming data is one of the most important areas in information technology toda
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/205.md
+++ b/src/content/newsletter/205.md
@@ -52,6 +52,8 @@ Production ML is hard. We are thrilled to join NeurIPS 2022 for the workshop tac
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/206.md
+++ b/src/content/newsletter/206.md
@@ -54,6 +54,8 @@ The text-book on Structure and Interpretation of Computer Programs, more popular
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/207.md
+++ b/src/content/newsletter/207.md
@@ -54,6 +54,8 @@ A fantastic milestone on the newly Linux Foundation adopted project, Pytorch has
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/208.md
+++ b/src/content/newsletter/208.md
@@ -52,6 +52,8 @@ ADBench is a comprehensive benchmark for evaluating anomaly detection algorithms
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/209.md
+++ b/src/content/newsletter/209.md
@@ -52,6 +52,8 @@ Although the deep learning hype has continuously delivered, most of the times we
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/21.md
+++ b/src/content/newsletter/21.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [PyCon + PyData Florence](https://www.pycon.it/en/) [02/05/2019] - Python X comes this year with a PyData focus in Florence, Italy.

--- a/src/content/newsletter/210.md
+++ b/src/content/newsletter/210.md
@@ -58,6 +58,8 @@ Developing production machine learning infrastructure is challenging, but findin
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/211.md
+++ b/src/content/newsletter/211.md
@@ -65,6 +65,8 @@ Explainability in machine learning is a hot topic, but one problem is that diffe
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/212.md
+++ b/src/content/newsletter/212.md
@@ -53,6 +53,8 @@ FastAPI is continuously adopted for productionisation of machine learning powere
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we'll be speaking at:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/213.md
+++ b/src/content/newsletter/213.md
@@ -50,6 +50,8 @@ We had to see this coming, a live podcast conversating with ChatGPT 🧠 Greyloc
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/214.md
+++ b/src/content/newsletter/214.md
@@ -52,6 +52,8 @@ Golang has become a highly popular language for distributed systems as well as d
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/215.md
+++ b/src/content/newsletter/215.md
@@ -52,6 +52,8 @@ The first production release of SQLAlchemy 2.0, is now available 🚀 This is an
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/216.md
+++ b/src/content/newsletter/216.md
@@ -52,6 +52,8 @@ Kubernetes has become the preferred tool for DevOps engineers to deploy and mana
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently:
 
 - [PyData Global 2022](https://pydata.org/global2022/) - 1st-3rd December @ Online

--- a/src/content/newsletter/217.md
+++ b/src/content/newsletter/217.md
@@ -54,6 +54,8 @@ React.js: The Documentary 🧑‍💻 Following the success of the Kubernetes Do
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently with published video:
 
 - NeurIPS 2021 - [Responsible AI (Workshop Keynote)](http://www.youtube.com/watch?v=57YpXjcj0Ho)

--- a/src/content/newsletter/218.md
+++ b/src/content/newsletter/218.md
@@ -54,6 +54,8 @@ A Categorical Archive of ChatGPT Failures 😅 Throughout the last couple of wee
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently with published video:
 
 - NeurIPS 2021 - [Responsible AI (Workshop Keynote)](http://www.youtube.com/watch?v=57YpXjcj0Ho)

--- a/src/content/newsletter/219.md
+++ b/src/content/newsletter/219.md
@@ -54,6 +54,8 @@ Unleashing ML Innovation at Spotify with Ray 💡 Spotify founded its machine le
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently with published video:
 
 - NeurIPS 2021 - [Responsible AI (Workshop Keynote)](http://www.youtube.com/watch?v=57YpXjcj0Ho)

--- a/src/content/newsletter/22.md
+++ b/src/content/newsletter/22.md
@@ -57,6 +57,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [PyCon + PyData Florence](https://www.pycon.it/en/) [02/05/2019] - Python X comes this year with a PyData focus in Florence, Italy.

--- a/src/content/newsletter/220.md
+++ b/src/content/newsletter/220.md
@@ -54,6 +54,8 @@ NVIDIA OSS Recommender System meets the MLOps ecosystem: building a production-r
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently with published video:
 
 - NeurIPS 2021 - [Responsible AI (Workshop Keynote)](http://www.youtube.com/watch?v=57YpXjcj0Ho)

--- a/src/content/newsletter/221.md
+++ b/src/content/newsletter/221.md
@@ -54,6 +54,8 @@ A comprehensive migration guide and comparison of Flask to FasfAPI by its author
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently with published video:
 
 - NeurIPS 2021 - [Responsible AI (Workshop Keynote)](http://www.youtube.com/watch?v=57YpXjcj0Ho)

--- a/src/content/newsletter/222.md
+++ b/src/content/newsletter/222.md
@@ -54,6 +54,8 @@ A great tutorial to automate your personal finances with Airflow 🌀 This tutor
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently with published video:
 
 - NeurIPS 2021 - [Responsible AI (Workshop Keynote)](http://www.youtube.com/watch?v=57YpXjcj0Ho)

--- a/src/content/newsletter/223.md
+++ b/src/content/newsletter/223.md
@@ -54,6 +54,8 @@ Google's free onlien Machine Learning Crash Course 💸 A course designed to pro
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences we spoke at recently with published video:
 
 - NeurIPS 2021 - [Responsible AI (Workshop Keynote)](http://www.youtube.com/watch?v=57YpXjcj0Ho)

--- a/src/content/newsletter/224.md
+++ b/src/content/newsletter/224.md
@@ -56,6 +56,8 @@ Bloomberg has released a new language model called BloombergGPT, specifically tr
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/225.md
+++ b/src/content/newsletter/225.md
@@ -56,6 +56,8 @@ Facebook/Meta shares their approach to organisation-wide MLOps 💡 Facebook/Met
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/226.md
+++ b/src/content/newsletter/226.md
@@ -56,6 +56,8 @@ ChatGPT hacks to increase developer productivity 🤔 This video dives into some
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/227.md
+++ b/src/content/newsletter/227.md
@@ -54,6 +54,8 @@ RocksDB Under The Hood 🛠️ RocksDB is an embeddable persistent key-value sto
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/228.md
+++ b/src/content/newsletter/228.md
@@ -54,6 +54,8 @@ The article describes building a simple deep neural network (DNN) from scratch i
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/229.md
+++ b/src/content/newsletter/229.md
@@ -53,6 +53,8 @@ Mojo is a new programming language designed to bridge the gap between research a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/23.md
+++ b/src/content/newsletter/23.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [PyCon + PyData Florence](https://www.pycon.it/en/) [02/05/2019] - Python X comes this year with a PyData focus in Florence, Italy.

--- a/src/content/newsletter/230.md
+++ b/src/content/newsletter/230.md
@@ -54,6 +54,8 @@ The Carnegie Mellon University (CMU) Database Group YouTube channel offers valua
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/231.md
+++ b/src/content/newsletter/231.md
@@ -54,6 +54,8 @@ Lightning AI has released an insightful evaluation across large language models,
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/232.md
+++ b/src/content/newsletter/232.md
@@ -54,6 +54,8 @@ In this article, AI pioneer Andrew Ng discusses his shift from "bits to things,"
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/233.md
+++ b/src/content/newsletter/233.md
@@ -56,6 +56,8 @@ An interesting resource that explores the real-cost of programmer interruptions 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/234.md
+++ b/src/content/newsletter/234.md
@@ -56,6 +56,8 @@ Securing AI Systems — Defensive Strategies 🥷 A great article that explores 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/235.md
+++ b/src/content/newsletter/235.md
@@ -54,6 +54,8 @@ The insightful article discusses Google's method to understand and reduce techni
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/236.md
+++ b/src/content/newsletter/236.md
@@ -54,6 +54,8 @@ The article outlines a set of security mitigation strategies for machine learnin
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/237.md
+++ b/src/content/newsletter/237.md
@@ -54,6 +54,8 @@ Fantastic episode of"Talk Python Podcast" on"Python at Netflix" featured two gue
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/238.md
+++ b/src/content/newsletter/238.md
@@ -54,6 +54,8 @@ Dealing with Train-serve Skew in Real-time ML Models: A Short Guide 🔭 A compr
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/239.md
+++ b/src/content/newsletter/239.md
@@ -56,6 +56,8 @@ Keras 3.0 reminds us the insightful journey that this project has undergone; now
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/24.md
+++ b/src/content/newsletter/24.md
@@ -66,6 +66,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [AI Conference Beijing](https://ai.oreilly.com.cn/ai-cn?locale=en) [18/06/2019] - O'Reilly's signature applied AI conference in Asia in Beijing, China.

--- a/src/content/newsletter/240.md
+++ b/src/content/newsletter/240.md
@@ -56,6 +56,8 @@ The one and only Sebastian Raschka on "Understanding and Coding the Self-Attenti
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/241.md
+++ b/src/content/newsletter/241.md
@@ -52,6 +52,8 @@ Estimating Causal Effect Using Propensity Score Matching 🔎 A great hands on a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/242.md
+++ b/src/content/newsletter/242.md
@@ -54,6 +54,8 @@ The insightful article discusses Google's method to understand and reduce techni
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/243.md
+++ b/src/content/newsletter/243.md
@@ -54,6 +54,8 @@ An interesting security vulnerability report has been published on the machine l
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/244.md
+++ b/src/content/newsletter/244.md
@@ -54,6 +54,8 @@ A plain english introduction to CAP Theorem 💡 For practitioners working with 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/245.md
+++ b/src/content/newsletter/245.md
@@ -54,6 +54,8 @@ Probabilistic Machine Learning: Advanced Topics - a fantastic free book to dive 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/246.md
+++ b/src/content/newsletter/246.md
@@ -54,6 +54,8 @@ This is one of the best resources out there to build an intuitive understanding 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/247.md
+++ b/src/content/newsletter/247.md
@@ -54,6 +54,8 @@ The Advanced NLP Course with SpaCy: Natural Language Processing has a vast and g
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/248.md
+++ b/src/content/newsletter/248.md
@@ -54,6 +54,8 @@ Death by a thousand microservices 🥷 A great critique on the tech industry's o
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/249.md
+++ b/src/content/newsletter/249.md
@@ -58,6 +58,8 @@ Every Programmer Should Know #1: Idempotency 💡 In the world of programming, t
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/25.md
+++ b/src/content/newsletter/25.md
@@ -65,6 +65,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [AI Conference Beijing](https://ai.oreilly.com.cn/ai-cn?locale=en) [18/06/2019] - O'Reilly's signature applied AI conference in Asia in Beijing, China.

--- a/src/content/newsletter/250.md
+++ b/src/content/newsletter/250.md
@@ -52,6 +52,8 @@ The Deep Learning Systems course from CMU is now available on YouTube offering a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/251.md
+++ b/src/content/newsletter/251.md
@@ -51,6 +51,8 @@ A comprehensive comparison of leading vector databases in 2023, emphasizing thei
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/252.md
+++ b/src/content/newsletter/252.md
@@ -51,6 +51,8 @@ A fantastic book providing an in-depth introduction to modern statistics with gr
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/253.md
+++ b/src/content/newsletter/253.md
@@ -51,6 +51,8 @@ Adept.ai has released a multimodal foundation model available on HuggingFace und
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/254.md
+++ b/src/content/newsletter/254.md
@@ -51,6 +51,8 @@ Any ML practitioner working with text will be caught by the intricacies of unico
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/255.md
+++ b/src/content/newsletter/255.md
@@ -50,6 +50,8 @@ Animated AI: A great resource that provides intuitive visual explanations of dif
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/256.md
+++ b/src/content/newsletter/256.md
@@ -52,6 +52,8 @@ The OECD adopted a new definition for AI systems: "An AI system is a machine-bas
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/257.md
+++ b/src/content/newsletter/257.md
@@ -52,6 +52,8 @@ Following the broad range of benchmarks across transformer-based LLMs, we now se
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/258.md
+++ b/src/content/newsletter/258.md
@@ -50,6 +50,8 @@ Machine Learning security continues to grow in importance across production syst
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/259.md
+++ b/src/content/newsletter/259.md
@@ -52,6 +52,8 @@ Code is read more times than it is written, however it's run more times than it'
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/26.md
+++ b/src/content/newsletter/26.md
@@ -60,6 +60,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [AI Conference Beijing](https://ai.oreilly.com.cn/ai-cn?locale=en) [18/06/2019] - O'Reilly's signature applied AI conference in Asia in Beijing, China.

--- a/src/content/newsletter/260.md
+++ b/src/content/newsletter/260.md
@@ -52,6 +52,8 @@ Challenges & Decisions of Designing a Distributed SQL Engine: An insightful reso
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/261.md
+++ b/src/content/newsletter/261.md
@@ -54,6 +54,8 @@ As we growingly interact with billion-scale datasets we require new paradigms to
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Check out our "MLOps Curriculum" from previous conferences:
 
 - [Responsible AI Workshop Keynote](http://www.youtube.com/watch?v=57YpXjcj0Ho) - [NeurIPS 202](http://www.youtube.com/watch?v=57YpXjcj0Ho)1

--- a/src/content/newsletter/262.md
+++ b/src/content/newsletter/262.md
@@ -52,6 +52,8 @@ Sebastian Raschka on Optimizing Large Language Models (LLMs) from a Dataset Pers
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming MLOps conferences:
 
 - [FOSDEM (AI & HPC)](https://fosdem.org/2024/) - 3rd February @ Belgium

--- a/src/content/newsletter/263.md
+++ b/src/content/newsletter/263.md
@@ -58,6 +58,8 @@ Cohere's free online LLM course: A great resource offeriong a comprehensive onli
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming MLOps conferences:
 
 - [FOSDEM (AI & HPC)](https://fosdem.org/2024/) - 3rd February @ Belgium

--- a/src/content/newsletter/264.md
+++ b/src/content/newsletter/264.md
@@ -56,6 +56,8 @@ Introducing Deep Learning for Relational Database Data Structures and Graph Rela
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming MLOps conferences:
 
 - [FOSDEM (AI & HPC)](https://fosdem.org/2024/) - 3rd February @ Belgium

--- a/src/content/newsletter/265.md
+++ b/src/content/newsletter/265.md
@@ -52,6 +52,8 @@ How to reduce cost of ranking by knowledge distillation in Recommender Systems: 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming MLOps conferences:
 
 - [FOSDEM (AI & HPC)](https://fosdem.org/2024/) - 3rd February @ Belgium

--- a/src/content/newsletter/266.md
+++ b/src/content/newsletter/266.md
@@ -52,6 +52,8 @@ Meta's Threads app achieved rapid success, garnering over 100 million sign-ups i
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming MLOps conferences:
 
 - [FOSDEM (AI & HPC)](https://fosdem.org/2024/) - 3rd February @ Belgium

--- a/src/content/newsletter/267.md
+++ b/src/content/newsletter/267.md
@@ -54,6 +54,8 @@ Top life-hack, keep a brag list of the wins you achieved: A great call to action
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming MLOps conferences:
 
 - [FOSDEM (AI & HPC)](https://fosdem.org/2024/) - 3rd February @ Belgium

--- a/src/content/newsletter/268.md
+++ b/src/content/newsletter/268.md
@@ -54,6 +54,8 @@ LLaVA-1.6 is released with improved reasoning, OCR, and world knowledge: An inte
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2024](https://www.wearedevelopers.com/world-congress) @ 17th July @ Germany

--- a/src/content/newsletter/269.md
+++ b/src/content/newsletter/269.md
@@ -54,6 +54,8 @@ The US FCC (ie Federal Communications Commission) has declared AI-generated voic
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2024](https://www.wearedevelopers.com/world-congress) @ 17th July @ Germany

--- a/src/content/newsletter/27.md
+++ b/src/content/newsletter/27.md
@@ -61,6 +61,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [AI Conference Beijing](https://ai.oreilly.com.cn/ai-cn?locale=en) [18/06/2019] - O'Reilly's signature applied AI conference in Asia in Beijing, China.

--- a/src/content/newsletter/270.md
+++ b/src/content/newsletter/270.md
@@ -52,6 +52,8 @@ Control vectors in LLMs introduce a promising concept that can be used to direct
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2024](https://www.wearedevelopers.com/world-congress) @ 17th July @ Germany

--- a/src/content/newsletter/271.md
+++ b/src/content/newsletter/271.md
@@ -52,6 +52,8 @@ Let's write GPT in 60 Lines of NumPy: What better way to learn a concept than im
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/272.md
+++ b/src/content/newsletter/272.md
@@ -52,6 +52,8 @@ A significant number of the limitations we face in LLMs can arise from the token
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/273.md
+++ b/src/content/newsletter/273.md
@@ -52,6 +52,8 @@ You can now train a 70b language model at home: Check out this interesting OSS f
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/274.md
+++ b/src/content/newsletter/274.md
@@ -52,6 +52,8 @@ High quality image generation becomes more attainable for daily use in your pers
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/275.md
+++ b/src/content/newsletter/275.md
@@ -52,6 +52,8 @@ The go-to resource to build strong practical foundations on forecasting is Rob H
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/276.md
+++ b/src/content/newsletter/276.md
@@ -52,6 +52,8 @@ The National Telecommunications and Information Administration releases the AI A
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/277.md
+++ b/src/content/newsletter/277.md
@@ -52,6 +52,8 @@ How to not die by a thousand cuts; or, how to think about software quality: The 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/278.md
+++ b/src/content/newsletter/278.md
@@ -52,6 +52,8 @@ The lifecycle of a production-grade AI code assistant to generate code completio
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/279.md
+++ b/src/content/newsletter/279.md
@@ -52,6 +52,8 @@ Meta has launched Llama 3: This is META's latest iteration of its open large lan
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/28.md
+++ b/src/content/newsletter/28.md
@@ -58,6 +58,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [AI Conference Beijing](https://ai.oreilly.com.cn/ai-cn?locale=en) [18/06/2019] - O'Reilly's signature applied AI conference in Asia in Beijing, China.

--- a/src/content/newsletter/280.md
+++ b/src/content/newsletter/280.md
@@ -52,6 +52,8 @@ A classic for excellent (and humourous) advice to software practitioners - The G
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/281.md
+++ b/src/content/newsletter/281.md
@@ -52,6 +52,8 @@ Chip Huyen shares great introspective advice on how to measure (and augment) per
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/282.md
+++ b/src/content/newsletter/282.md
@@ -52,6 +52,8 @@ The Illustrated Word2vec is a classic in ML for the key foundation concept of em
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/283.md
+++ b/src/content/newsletter/283.md
@@ -52,6 +52,8 @@ GPUs Go Brrr - or how to optimize AI compute on GPUs: Practical strategies and p
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/284.md
+++ b/src/content/newsletter/284.md
@@ -52,6 +52,8 @@ The Generative AI Red Teaming Challenge Transparency Report 2024 showcasing AI b
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/285.md
+++ b/src/content/newsletter/285.md
@@ -54,6 +54,8 @@ Japan is launching a national initiative to make all publicly funded research op
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/286.md
+++ b/src/content/newsletter/286.md
@@ -56,6 +56,8 @@ Microsoft enters the Forecasting Foundation Model Race with their latest release
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/287.md
+++ b/src/content/newsletter/287.md
@@ -54,6 +54,8 @@ Apple's Private Cloud Compute: A new frontier for AI privacy in the cloud. A gre
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/288.md
+++ b/src/content/newsletter/288.md
@@ -52,6 +52,8 @@ Distributed systems are a fundamental concept to learn for practitioners in the 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/289.md
+++ b/src/content/newsletter/289.md
@@ -52,6 +52,8 @@ Key lessons from 15 years of programming experience: A great resource that provi
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/29.md
+++ b/src/content/newsletter/29.md
@@ -60,6 +60,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [AI Conference Beijing](https://ai.oreilly.com.cn/ai-cn?locale=en) [18/06/2019] - O'Reilly's signature applied AI conference in Asia in Beijing, China.

--- a/src/content/newsletter/290.md
+++ b/src/content/newsletter/290.md
@@ -52,6 +52,8 @@ AI Video generation continues to blow our minds - this last week we saw Runway's
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/291.md
+++ b/src/content/newsletter/291.md
@@ -51,6 +51,8 @@ Eugene Yan on how to effectively hire ML/AI engineers: A great resource covering
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/292.md
+++ b/src/content/newsletter/292.md
@@ -48,6 +48,8 @@ GitHub's Chief Product Officer Inbal Shani dives into the transformative impact 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/293.md
+++ b/src/content/newsletter/293.md
@@ -53,6 +53,8 @@ Google enters once again the forecasting foundation model race after their relea
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/294.md
+++ b/src/content/newsletter/294.md
@@ -51,6 +51,8 @@ A great set of lessons learned from 35 years of software development: 1) Priorit
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/295.md
+++ b/src/content/newsletter/295.md
@@ -51,6 +51,8 @@ Apple also joins the race of foundation AI models with an advanced ~3 billion pa
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/296.md
+++ b/src/content/newsletter/296.md
@@ -53,6 +53,8 @@ Really awesome (and visually pleasing) introduction to probability and statistic
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [AI in Production 2024](https://home.mlops.community/public/events/ai-in-production-2024-02-15) @ 15th February @ Virtual

--- a/src/content/newsletter/297.md
+++ b/src/content/newsletter/297.md
@@ -54,6 +54,8 @@ Good Refactoring vs Bad Refactoring, a great reminder that not all refactors are
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/298.md
+++ b/src/content/newsletter/298.md
@@ -53,6 +53,8 @@ The article "Engineer’s Guide to Convincing Your Product Manager to Prioritize
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/299.md
+++ b/src/content/newsletter/299.md
@@ -54,6 +54,8 @@ One of the age-old lessons on clean-code: the importance of writing explicit, cl
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/30.md
+++ b/src/content/newsletter/30.md
@@ -60,6 +60,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [AI Conference Beijing](https://ai.oreilly.com.cn/ai-cn?locale=en) [18/06/2019] - O'Reilly's signature applied AI conference in Asia in Beijing, China.

--- a/src/content/newsletter/300.md
+++ b/src/content/newsletter/300.md
@@ -54,6 +54,8 @@ Open source time series databases like Prometheus and InfluxDB have become growi
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/301.md
+++ b/src/content/newsletter/301.md
@@ -55,6 +55,8 @@ Exciting to continue seeing developments in GPGPU with PolaRS (aka Pandas in Rus
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/302.md
+++ b/src/content/newsletter/302.md
@@ -55,6 +55,8 @@ This is the time to learn General-Processing GPU compute programming, and GPU-Pu
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/303.md
+++ b/src/content/newsletter/303.md
@@ -55,6 +55,8 @@ A recent research paper from Zalando presenting a framework to leverage multimod
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/304.md
+++ b/src/content/newsletter/304.md
@@ -55,6 +55,8 @@ One of the biggest challengers to productivity in development is cognitive load,
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/305.md
+++ b/src/content/newsletter/305.md
@@ -53,6 +53,8 @@ Meta's FAIR team has released several new AI research artifacts to continue supp
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/306.md
+++ b/src/content/newsletter/306.md
@@ -53,6 +53,8 @@ Efficiency in LLMs is becoming growingly important; Meta has now released quanti
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/307.md
+++ b/src/content/newsletter/307.md
@@ -53,6 +53,8 @@ One of the most pressing challenges when deploying GenAI products is ensuring ro
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/308.md
+++ b/src/content/newsletter/308.md
@@ -53,6 +53,8 @@ Recently we have seen OpenAI exploring other avenues for innovation, most recent
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/309.md
+++ b/src/content/newsletter/309.md
@@ -53,6 +53,8 @@ The rise of generative AI and Large Language Models has transformed the role of 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/31.md
+++ b/src/content/newsletter/31.md
@@ -58,6 +58,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/310.md
+++ b/src/content/newsletter/310.md
@@ -53,6 +53,8 @@ Anthropic has detailed its approach to responsible AI through risk assessment an
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/311.md
+++ b/src/content/newsletter/311.md
@@ -53,6 +53,8 @@ The time has arrived to brush up our skills and jump into the advent of code. Th
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/312.md
+++ b/src/content/newsletter/312.md
@@ -51,6 +51,8 @@ Microsoft demystifies the concept of "Bad Days" in development through a quantit
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/313.md
+++ b/src/content/newsletter/313.md
@@ -51,6 +51,8 @@ OpenAI has finally released their Text-to-Video SORA model as a public offering!
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/314.md
+++ b/src/content/newsletter/314.md
@@ -51,6 +51,8 @@ OpenAI O1's impressive performance at high compute ($3k est. per task) highlight
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/315.md
+++ b/src/content/newsletter/315.md
@@ -55,6 +55,8 @@ NVIDIA CUDA has led the way on ML inference by quite a margin, however slowly ot
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/316.md
+++ b/src/content/newsletter/316.md
@@ -55,6 +55,8 @@ Deepseek AI took the world by surprise with a foundation model from China that s
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/317.md
+++ b/src/content/newsletter/317.md
@@ -55,6 +55,8 @@ Did you know it's possible to extract AI models shipped with Android Apps? This 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [TUM AI@WORK](https://tum-cso.notion.site/AI-WORK-How-AI-is-changing-leadership-work-and-collaboration-7c5b905f85e34f26b4198fb4a7f8bd1b) 10th October @ Germany

--- a/src/content/newsletter/318.md
+++ b/src/content/newsletter/318.md
@@ -53,6 +53,8 @@ Yet another article on "Papers Every Developer Should Read", however we can't ge
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/319.md
+++ b/src/content/newsletter/319.md
@@ -53,6 +53,8 @@ OpenAI brings another innovation that they hope is going to drive similar hype a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/32.md
+++ b/src/content/newsletter/32.md
@@ -61,6 +61,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/320.md
+++ b/src/content/newsletter/320.md
@@ -51,6 +51,8 @@ If you want to go beyond the hype of the DeepSeek-R1 new model, this is great re
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/321.md
+++ b/src/content/newsletter/321.md
@@ -53,6 +53,8 @@ This reflective piece revisits a decade of evolving software development practic
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/322.md
+++ b/src/content/newsletter/322.md
@@ -53,6 +53,8 @@ What better way to learn something that by building it from scratch! This open s
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/323.md
+++ b/src/content/newsletter/323.md
@@ -53,6 +53,8 @@ It is interesting not only to see Bluesky’s meteoric rise, but also their abil
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/324.md
+++ b/src/content/newsletter/324.md
@@ -53,6 +53,8 @@ We are seeing a massive surprise, with China's TikTok open sourcing a major comp
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/325.md
+++ b/src/content/newsletter/325.md
@@ -53,6 +53,8 @@ Every day we see ML models are growing higher and requiring more compute, howeve
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/326.md
+++ b/src/content/newsletter/326.md
@@ -53,6 +53,8 @@ The Startup CTO’s Handbook is a great and pragmatic guide for tech leaders tra
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [KubeCon AI Day 2025](https://colocatedeventseu2025.sched.com/overview/type/Cloud+Native+%2B+Kubernetes+AI+Day) - 1st April @ London

--- a/src/content/newsletter/327.md
+++ b/src/content/newsletter/327.md
@@ -53,6 +53,8 @@ What a better way to continuously improve knowledge than by diving into some of 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [KubeCon AI Day 2025](https://colocatedeventseu2025.sched.com/overview/type/Cloud+Native+%2B+Kubernetes+AI+Day) - 1st April @ London

--- a/src/content/newsletter/328.md
+++ b/src/content/newsletter/328.md
@@ -55,6 +55,8 @@ The internet has been increasingly discussing and showcasing OpenAI’s latest G
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [KubeCon AI Day 2025](https://colocatedeventseu2025.sched.com/overview/type/Cloud+Native+%2B+Kubernetes+AI+Day) - 1st April @ London

--- a/src/content/newsletter/329.md
+++ b/src/content/newsletter/329.md
@@ -53,6 +53,8 @@ What better way to dive into the field of Reinforcement Learning than by diving 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [KubeCon AI Day 2025](https://colocatedeventseu2025.sched.com/overview/type/Cloud+Native+%2B+Kubernetes+AI+Day) - 1st April @ London

--- a/src/content/newsletter/33.md
+++ b/src/content/newsletter/33.md
@@ -61,6 +61,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/330.md
+++ b/src/content/newsletter/330.md
@@ -53,6 +53,8 @@ It seems that Google DeepMind may actually be winning on most GenAI fronts: This
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [KubeCon AI Day 2025](https://colocatedeventseu2025.sched.com/overview/type/Cloud+Native+%2B+Kubernetes+AI+Day) - 1st April @ London

--- a/src/content/newsletter/331.md
+++ b/src/content/newsletter/331.md
@@ -53,6 +53,8 @@ Key one-liner lessons from the best programmers: 1) Read the Reference; 2) Know 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [KubeCon AI Day 2025](https://colocatedeventseu2025.sched.com/overview/type/Cloud+Native+%2B+Kubernetes+AI+Day) - 1st April @ London

--- a/src/content/newsletter/332.md
+++ b/src/content/newsletter/332.md
@@ -53,6 +53,8 @@ Google Deepmind keeps innovating with their Open Weights family of Gemma 3 QAT M
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/333.md
+++ b/src/content/newsletter/333.md
@@ -53,6 +53,8 @@ It is hard to make the leap from individual contributor to people leader in the 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/334.md
+++ b/src/content/newsletter/334.md
@@ -53,6 +53,8 @@ Diving into PyTorch’s internals can provide practitioners with meaningful intu
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/335.md
+++ b/src/content/newsletter/335.md
@@ -53,6 +53,8 @@ DeepMind releases AlphaEvolve as a new coding agent to also challenge the compet
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/336.md
+++ b/src/content/newsletter/336.md
@@ -51,6 +51,8 @@ AI red teaming is only becoming more critical with the growing adoption of AI an
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/337.md
+++ b/src/content/newsletter/337.md
@@ -53,6 +53,8 @@ Perplexity has launched Perplexity Labs extending DeepResearch capabilities with
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/338.md
+++ b/src/content/newsletter/338.md
@@ -53,6 +53,8 @@ It is now clear that fast and precise code retrieval is critical for next-gen de
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/339.md
+++ b/src/content/newsletter/339.md
@@ -57,6 +57,8 @@ High-quality voice-cloning and synthetic text-to-speech is going to impact a sig
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/34.md
+++ b/src/content/newsletter/34.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/340.md
+++ b/src/content/newsletter/340.md
@@ -53,6 +53,8 @@ Quantum computing is an exciting emerging field intersecting with AI, and this 2
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/341.md
+++ b/src/content/newsletter/341.md
@@ -53,6 +53,8 @@ Your favourite AI LLM may be hiding malware! Recent research EvilModel shows how
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/342.md
+++ b/src/content/newsletter/342.md
@@ -53,6 +53,8 @@ As of today, scale in ML tends to define success across some of the leading play
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/343.md
+++ b/src/content/newsletter/343.md
@@ -53,6 +53,8 @@ We see surveys showing improvements in productivity with AI, but this survey act
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/344.md
+++ b/src/content/newsletter/344.md
@@ -53,6 +53,8 @@ The principal engineering community at Amazon is renown for having a high bar on
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/345.md
+++ b/src/content/newsletter/345.md
@@ -53,6 +53,8 @@ In an era where we everything we hear is about vibe-coding, it's always nice to 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/346.md
+++ b/src/content/newsletter/346.md
@@ -53,6 +53,8 @@ Huge leap forward from the ACM making the move towards full open-access research
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/347.md
+++ b/src/content/newsletter/347.md
@@ -53,6 +53,8 @@ MoE LLMs are how we scale capability without scaling cost. A minimal, Apache-2.0
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/348.md
+++ b/src/content/newsletter/348.md
@@ -53,6 +53,8 @@ What are the best practices for designing and building Agentic Systems? Here's a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/349.md
+++ b/src/content/newsletter/349.md
@@ -53,6 +53,8 @@ A new shortest-path graph algorithm has emerged to take on good old Djikstra, ho
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/35.md
+++ b/src/content/newsletter/35.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/350.md
+++ b/src/content/newsletter/350.md
@@ -62,6 +62,8 @@ The SpaCy team put together a while back a case against LLM maximalism, making a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/351.md
+++ b/src/content/newsletter/351.md
@@ -59,6 +59,8 @@ Embeddings are an essential component in AI systems, and understanding their sca
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/352.md
+++ b/src/content/newsletter/352.md
@@ -59,6 +59,8 @@ It is fascinating to see how AI-assisted rapid prototyping is completely changin
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/353.md
+++ b/src/content/newsletter/353.md
@@ -59,6 +59,8 @@ This is a classic, and hands down one of the best tech talks available online: i
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/354.md
+++ b/src/content/newsletter/354.md
@@ -57,6 +57,8 @@ As a leader it is the norm to be in a room full of experts - what are then best 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/355.md
+++ b/src/content/newsletter/355.md
@@ -55,6 +55,8 @@ One of the best ways to learn a concept is by going through the implementation; 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/356.md
+++ b/src/content/newsletter/356.md
@@ -57,6 +57,8 @@ How do we measure AI productivity? Here is how Google, GitHub, Microsoft, Dropbo
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/357.md
+++ b/src/content/newsletter/357.md
@@ -55,6 +55,8 @@ There are critical lessons that we can take on from the movement that drives the
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/358.md
+++ b/src/content/newsletter/358.md
@@ -55,6 +55,8 @@ Ray is joining the Linux Foundation; I have to say this is one that I am extreme
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/359.md
+++ b/src/content/newsletter/359.md
@@ -61,6 +61,8 @@ This is a fantastic example of "learning PyTorch the Hard Way", but often one of
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/36.md
+++ b/src/content/newsletter/36.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/360.md
+++ b/src/content/newsletter/360.md
@@ -59,6 +59,8 @@ Today LLMs powered systems rely heavily on retrieval engines; this new benchmark
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/361.md
+++ b/src/content/newsletter/361.md
@@ -59,6 +59,8 @@ Time-series forecasting quietly runs the modern world, and the race for Forecast
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/362.md
+++ b/src/content/newsletter/362.md
@@ -59,6 +59,8 @@ DuckDB is great for local development. But what if you want to take DuckDB to di
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/363.md
+++ b/src/content/newsletter/363.md
@@ -63,6 +63,8 @@ On this topic funnily enough I ended up attending to build a custom parser, lexe
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/364.md
+++ b/src/content/newsletter/364.md
@@ -55,6 +55,8 @@ In production ML, the real outages usually come not from your models but from th
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/365.md
+++ b/src/content/newsletter/365.md
@@ -55,6 +55,8 @@ Ben Evans releases his annual keynote on "AI Eats the World" for the 2025 editio
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Upcoming conferences where we're speaking:
 
 - [WeAreDevelopers 2025](https://www.wearedevelopers.com/) - 9th July @ Berlin

--- a/src/content/newsletter/366.md
+++ b/src/content/newsletter/366.md
@@ -117,6 +117,8 @@ Top 10 AI Python Libraries:
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences for 2026 coming soon! For the meantime, in case you missed our talks:
 
 - The State of AI in 2025 - [WeAreDevelopers 2025](https://www.youtube.com/watch?v=v2LENQOG-Xg)

--- a/src/content/newsletter/367.md
+++ b/src/content/newsletter/367.md
@@ -71,6 +71,8 @@ What better way to kick off 2026 than with a review of foundational data science
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences for 2026 coming soon! For the meantime, in case you missed our talks:
 
 - The State of AI in 2025 - [WeAreDevelopers 2025](https://www.youtube.com/watch?v=v2LENQOG-Xg)

--- a/src/content/newsletter/368.md
+++ b/src/content/newsletter/368.md
@@ -71,6 +71,8 @@ OpenRouter has just dropped an in-depth analysis from 100 trillion tokens of rea
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences for 2026 coming soon! For the meantime, in case you missed our talks:
 
 - The State of AI in 2025 - [WeAreDevelopers 2025](https://www.youtube.com/watch?v=v2LENQOG-Xg)

--- a/src/content/newsletter/369.md
+++ b/src/content/newsletter/369.md
@@ -58,6 +58,8 @@ METR has released an in-depth study that measures the ability for LLM agents to 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences for 2026 coming soon! For the meantime, in case you missed our talks:
 
 - The State of AI in 2025 - [WeAreDevelopers 2025](https://www.youtube.com/watch?v=v2LENQOG-Xg)

--- a/src/content/newsletter/37.md
+++ b/src/content/newsletter/37.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/370.md
+++ b/src/content/newsletter/370.md
@@ -55,6 +55,8 @@ Data processing is the quiet force multiplier behind every successful ML system,
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Conferences for 2026 coming soon! For the meantime, in case you missed our talks:
 
 - The State of AI in 2025 - [WeAreDevelopers 2025](https://www.youtube.com/watch?v=v2LENQOG-Xg)

--- a/src/content/newsletter/371.md
+++ b/src/content/newsletter/371.md
@@ -59,6 +59,8 @@ Here are the 7 deadly sins of engineering productivity: 1) Context Switching; 2)
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/372.md
+++ b/src/content/newsletter/372.md
@@ -57,6 +57,8 @@ Another interesting Large-Model from Chinese Giant MeiTuan, this time covering a
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/373.md
+++ b/src/content/newsletter/373.md
@@ -80,6 +80,8 @@ Workflow orchestration is the backbone of production ML, so it was quite interes
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/374.md
+++ b/src/content/newsletter/374.md
@@ -107,6 +107,8 @@ Google has released Deep Think 3, which basically takes Deep Research to it's ab
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/375.md
+++ b/src/content/newsletter/375.md
@@ -67,6 +67,8 @@ On the topic of side-projects: This weekend I asked copilot to build me a joke w
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/376.md
+++ b/src/content/newsletter/376.md
@@ -102,6 +102,8 @@ Sebastian Raschka is at it again with his (WIP) Manning book "Build A Reasoning 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/377.md
+++ b/src/content/newsletter/377.md
@@ -63,6 +63,8 @@ In production ML, efficiency increasingly determines success, and Meta published
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/378.md
+++ b/src/content/newsletter/378.md
@@ -53,6 +53,8 @@ We all saw the launch of the Macbook Neo last week; but the real question is: ho
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/379.md
+++ b/src/content/newsletter/379.md
@@ -51,6 +51,8 @@ The next wave of AI product differentiation will be won or lost in the data laye
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/38.md
+++ b/src/content/newsletter/38.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/380.md
+++ b/src/content/newsletter/380.md
@@ -51,6 +51,8 @@ Forecasting is where machine learning stops being interesting and starts being o
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/) - Sept @ Berlin

--- a/src/content/newsletter/381.md
+++ b/src/content/newsletter/381.md
@@ -53,6 +53,8 @@ Stanford is releasing their new 2026 course on Transformer models for FREE! CS25
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/) - Sept @ Berlin

--- a/src/content/newsletter/382.md
+++ b/src/content/newsletter/382.md
@@ -75,6 +75,8 @@ The Linux Kernel now has released guidelines for vibe coded contributions! And u
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/383.md
+++ b/src/content/newsletter/383.md
@@ -51,6 +51,8 @@ What do 81,000 people want from AI? Anthropic has taken the question and provide
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/384.md
+++ b/src/content/newsletter/384.md
@@ -51,6 +51,8 @@ OpenAI has released their latest model GPT-5.5. It seems this model is positione
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/385.md
+++ b/src/content/newsletter/385.md
@@ -51,6 +51,8 @@ It is quite interesting that MLflow has recently been leading the charge on ML t
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/386.md
+++ b/src/content/newsletter/386.md
@@ -53,6 +53,8 @@ Inference speed is becoming one of the most important battlegrounds in productio
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/387.md
+++ b/src/content/newsletter/387.md
@@ -51,6 +51,8 @@ Mozilla shared a great behind-the-scenes look at how they used Claude Mythos Pre
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/388.md
+++ b/src/content/newsletter/388.md
@@ -51,6 +51,8 @@ NVIDIA just dropped a high efficiency open-source stack for high-resolution imag
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/389.md
+++ b/src/content/newsletter/389.md
@@ -51,6 +51,8 @@ An interesting release of a new massive open text-to-image dataset: The MONET da
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [eTail Europe](https://etailgermany.wbresearch.com/) - March @ Berlin

--- a/src/content/newsletter/39.md
+++ b/src/content/newsletter/39.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/390.md
+++ b/src/content/newsletter/390.md
@@ -55,6 +55,8 @@ Last week NVIDIA and Microsoft announced the release of the NVIDIA RTX Spark, an
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/391.md
+++ b/src/content/newsletter/391.md
@@ -51,6 +51,8 @@ The Chinese startup behind Kimi (Moonshot AI) just released Kimi K2.7 Code, and 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/392.md
+++ b/src/content/newsletter/392.md
@@ -51,6 +51,8 @@ NVIDIA has published a new framework + paper to bring Rust's memory safety into 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/393.md
+++ b/src/content/newsletter/393.md
@@ -53,6 +53,8 @@ O’Reilly's published the 2026 Radar Trends this month, and this has quite a us
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/394.md
+++ b/src/content/newsletter/394.md
@@ -51,6 +51,8 @@ Disclosure of serious cyber vulnerabilities spiked around the release of Claude 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/395.md
+++ b/src/content/newsletter/395.md
@@ -51,6 +51,8 @@ X / Xai / SpaceXAI (or whatever is twitter's latest nickname) has trained a new 
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/396.md
+++ b/src/content/newsletter/396.md
@@ -51,6 +51,8 @@ Moonshot AI has released Kimi K3, ruining the party for Anthropic's Fable and Op
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/397.md
+++ b/src/content/newsletter/397.md
@@ -59,6 +59,8 @@ The second part of the "DuckDB Internals" series is out! This is a great write-u
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/398.md
+++ b/src/content/newsletter/398.md
@@ -51,6 +51,8 @@ OpenAI (self) reports that an internal version of its forthcoming Astra model ge
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/399.md
+++ b/src/content/newsletter/399.md
@@ -61,6 +61,8 @@ Europe strikes again! Mistral has released Shieldstral, an open-weights multimod
 
 The MLOps ecosystem continues to grow at break-neck speeds, making it ever harder for us as practitioners to stay up to date with relevant developments. A fantsatic way to keep on-top of relevant resources is through the great community and events that the MLOps and Production ML ecosystem offers. This is the reason why we have started curating a list of upcoming events in the space, which are outlined below.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Events we are speaking at this year:
 
 - [Signals Conference](https://signalsconf.io/#tickets) - September @ Berlin

--- a/src/content/newsletter/40.md
+++ b/src/content/newsletter/40.md
@@ -61,6 +61,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/41.md
+++ b/src/content/newsletter/41.md
@@ -61,6 +61,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/42.md
+++ b/src/content/newsletter/42.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/43.md
+++ b/src/content/newsletter/43.md
@@ -59,6 +59,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/44.md
+++ b/src/content/newsletter/44.md
@@ -58,6 +58,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/45.md
+++ b/src/content/newsletter/45.md
@@ -69,6 +69,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/46.md
+++ b/src/content/newsletter/46.md
@@ -70,6 +70,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/47.md
+++ b/src/content/newsletter/47.md
@@ -70,6 +70,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/48.md
+++ b/src/content/newsletter/48.md
@@ -70,6 +70,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/49.md
+++ b/src/content/newsletter/49.md
@@ -70,6 +70,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/50.md
+++ b/src/content/newsletter/50.md
@@ -70,6 +70,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/51.md
+++ b/src/content/newsletter/51.md
@@ -70,6 +70,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/52.md
+++ b/src/content/newsletter/52.md
@@ -70,6 +70,8 @@ If you know of any libraries that are not in the ["Awesome MLOps"](https://githu
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical & Scientific Conferences
 
 - [EURNLP 2019 \[11/10/2019\]](https://www.eurnlp.org/) - European NLP Research summit in London, UK.

--- a/src/content/newsletter/6.md
+++ b/src/content/newsletter/6.md
@@ -82,6 +82,8 @@ Since last week, we started showcasing Machine Learning Engineering jobs (primar
 
 From this week on, we will be featuring conferences that are primarily machine learning or that have a core ML track (primarily in Europe for now) to help our community to stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [FOSDEM](https://fosdem.org) [02/02/2019] - Europe's largest open source conference in Brussels, Belgium.

--- a/src/content/newsletter/7.md
+++ b/src/content/newsletter/7.md
@@ -81,6 +81,8 @@ Since last week, we started showcasing Machine Learning Engineering jobs (primar
 
 From this week on, we will be featuring conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [FOSDEM](https://fosdem.org) [02/02/2019] - Europe's largest open source conference in Brussels, Belgium.

--- a/src/content/newsletter/8.md
+++ b/src/content/newsletter/8.md
@@ -83,6 +83,8 @@ We showcase Machine Learning Engineering jobs (primarily in London for now) to h
 
 From this week on, we will be featuring conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [FOSDEM](https://fosdem.org) [02/02/2019] - Europe's largest open source conference in Brussels, Belgium.

--- a/src/content/newsletter/9.md
+++ b/src/content/newsletter/9.md
@@ -85,6 +85,8 @@ We showcase Machine Learning Engineering jobs (primarily in London for now) to h
 
 We feature conferences that have core ML tracks (primarily in Europe for now) to help our community stay up to date with great events coming up.
 
+You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
+
 ### Technical Conferences
 
 - [PyCon Belarus](https://by.pycon.org/) [15/02/2019] - The 5th edition of the Python conference in Minsk, Belarus.


### PR DESCRIPTION
## Summary

- insert one uniform backlink paragraph into the events block of every newsletter issue that has one, so an issue reached through search is not a dead end for the talks archive and the upcoming events list
- the copy, identical in all 268 issues:

  ```
  You can also find our upcoming events and past talk recordings on the [talks and events page](/talks-and-events/).
  ```

- add a check to the `newsletter-issue` skill so the line survives the weekly events-list pruning

Out of scope, still open in TODO.md: generating the events block from the events collection.

## Variant analysis

Sampled issues 1, 6, 23, 52, 53, 60, 100, 150, 178, 179, 200 and 396 before scripting. The events block exists in exactly two structural forms, and both share the same shape: `##` heading, one lede paragraph, then `###` subheadings with link lists.

| Variant                                                     | Issues        | Count |
| ----------------------------------------------------------- | ------------- | ----- |
| `## Upcoming MLOps Events`                                   | 179 to 399    | 216   |
| `## MLConf = [Conferences & Events](/newsletter/N/#mlconfs)` | 6 to 52       | 52    |

The `MLConf` heading anchors five different issue numbers (`/newsletter/6/`, `/11/`, `/17/`, `/20/`, `/23/`), so the matcher takes the digits as a wildcard. Headings that merely contain the word "Events" (`## [MLOps London Meetup May](…/events/…)`, `## [AI Conferences Gone Virtual 2020](/newsletter/73/)`) are ordinary article sections, not the events block, and are deliberately not matched.

Insertion point is its own paragraph immediately after the block lede, before the first `###` or list item. That keeps the sentence in prose rather than trailing a list, per the "prose around widgets" rule, and reads the same in both eras.

## Modified and skipped

- **268 modified**, each a single two-line insertion. `git diff --numstat` is `2 0` for all 268 files, and the set of added lines across the whole diff is exactly the blank line plus the one sentence.
- **131 skipped**, all for the same reason: no events block heading in either variant. These are issues **1 to 5** and **53 to 178** — the two eras that published no events section at all (1 to 5 predate it; it lapsed between 53 and 178 and returned in 179). The script reports every skip with its reason and never guesses at a location.

The one-off script lived under `./tmp` and is not committed. It also skipped any issue already containing `/talks-and-events/`; none did.

## Template

New issues need no template edit of their own: `scripts/newsletter/new-issue.mjs` copies the entire events tail forward verbatim from the previous issue, so the paragraph propagates with the rest of the block. The risk is a human dropping it while pruning stale events, so `.claude/skills/newsletter-issue/SKILL.md` step 5 now names the line and marks it as a check rather than an edit.

## Before / after

Issue 396 events block at 1440x1000, production build.

| Before | After |
| ------ | ----- |
| <img src="https://raw.githubusercontent.com/EthicalML/ethical/evidence/newsletter-events-backlink/before.png" width="480"> | <img src="https://raw.githubusercontent.com/EthicalML/ethical/evidence/newsletter-events-backlink/after.png" width="480"> |

The images live on the throwaway `evidence/newsletter-events-backlink` branch (screenshots only, nothing to merge); delete it whenever this PR is closed.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run check:ratchet` (0 errors, 0 warnings, 0 hints)
- clean-cache `npm run build` after removing `.astro` (450 pages indexed, no frontmatter or schema failures, so all 268 edited files still parse)
- built output: 268 issue pages plus `dist/newsletter/rss.xml` contain the link; spot-checked issue 6 (early, MLConf variant), 23 (early), 200 (middle) and 396 (recent), each rendering `<p data-reveal="">… <a href="/talks-and-events/">talks and events page</a>.</p>` with no `target="_blank"`, which is the correct internal-link treatment
- `npm run verify:dom` for `/newsletter/396/` and `/newsletter/23/` at 1440x1000 and 420x900: no failures, no errors

Labelled `visual-change`: this adds visible copy to 268 newsletter routes, so the pixel sweep is expected to move.
