### PR TITLE
copy: describe frontier AI as open, not accountable, to people and society

### DIFF
--- a/src/components/FootnoteBand.astro
+++ b/src/components/FootnoteBand.astro
@@ -4,7 +4,7 @@ import AffiliationMarquee from './AffiliationMarquee.astro';
 const footer = {
   about: {
     eyebrow: 'ABOUT THE INSTITUTE',
-    text: 'An independent research institute working to ensure that frontier AI is safe, aligned and accountable to people and society.',
+    text: 'An independent research institute working to ensure that frontier AI is safe, aligned and open to people and society.',
   },
   publicationsEyebrow: 'FROM THE INSTITUTE',
   elsewhere: {

--- a/src/components/FootnoteBand.astro
+++ b/src/components/FootnoteBand.astro
@@ -4,7 +4,7 @@ import AffiliationMarquee from './AffiliationMarquee.astro';
 const footer = {
   about: {
     eyebrow: 'ABOUT THE INSTITUTE',
-    text: 'An independent research institute working to ensure that frontier AI is safe, aligned and open to people and society.',
+    text: 'An independent research institute working to ensure that frontier AI is safe, aligned and open for people and society.',
   },
   publicationsEyebrow: 'FROM THE INSTITUTE',
   elsewhere: {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ import FootnoteBand from '../components/FootnoteBand.astro';
 import { siteTitle } from '../data/navigation';
 import { authors } from '../data/authors';
 
-const metaDescription = 'An independent research institute working to ensure that frontier AI is safe, aligned and open to people and society.';
+const metaDescription = 'An independent research institute working to ensure that frontier AI is safe, aligned and open for people and society.';
 const ogImage = '/images/banner.jpg';
 const { frontmatter = {} } = Astro.props;
 const title = frontmatter.title ?? siteTitle;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ import FootnoteBand from '../components/FootnoteBand.astro';
 import { siteTitle } from '../data/navigation';
 import { authors } from '../data/authors';
 
-const metaDescription = 'An independent research institute working to ensure that frontier AI is safe, aligned and accountable to people and society.';
+const metaDescription = 'An independent research institute working to ensure that frontier AI is safe, aligned and open to people and society.';
 const ogImage = '/images/banner.jpg';
 const { frontmatter = {} } = Astro.props;
 const title = frontmatter.title ?? siteTitle;

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -1,7 +1,7 @@
 ---
 title: About the Institute
 seoTitle: About the Institute for Ethical AI Alignment & Safety
-description: Learn about the Institute's history, mission and independent work to make frontier AI safe, aligned and accountable to people and society.
+description: Learn about the Institute's history, mission and independent work to make frontier AI safe, aligned and open to people and society.
 layout: ../layouts/ProseLayout.astro
 ---
 
@@ -9,7 +9,7 @@ import { PersonSchema } from '../components/prose/components.js';
 
 Founded in 2017, the Institute is coordinated by its founder. Network members join and contribute for a time.
 
-We are an independent research institute with a mission to ensure that frontier AI is safe, aligned and accountable to people and society.
+We are an independent research institute with a mission to ensure that frontier AI is safe, aligned and open to people and society.
 {/* <!-- PROPOSAL: pending owner copy review --> */}
 
 ## Methods and implementation

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -1,7 +1,7 @@
 ---
 title: About the Institute
 seoTitle: About the Institute for Ethical AI Alignment & Safety
-description: Learn about the Institute's history, mission and independent work to make frontier AI safe, aligned and open to people and society.
+description: Learn about the Institute's history, mission and independent work to make frontier AI safe, aligned and open for people and society.
 layout: ../layouts/ProseLayout.astro
 ---
 
@@ -9,7 +9,7 @@ import { PersonSchema } from '../components/prose/components.js';
 
 Founded in 2017, the Institute is coordinated by its founder. Network members join and contribute for a time.
 
-We are an independent research institute with a mission to ensure that frontier AI is safe, aligned and open to people and society.
+We are an independent research institute with a mission to ensure that frontier AI is safe, aligned and open for people and society.
 {/* <!-- PROPOSAL: pending owner copy review --> */}
 
 ## Methods and implementation

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/BaseLayout.astro
 title: The Institute for Ethical AI Alignment & Safety
-description: An independent research institute working to ensure that frontier AI is safe, aligned and open to people and society.
+description: An independent research institute working to ensure that frontier AI is safe, aligned and open for people and society.
 hero:
   status: REACH OUT · SUBSCRIBE · APPLY TO JOIN
   status_href: '#join'
@@ -11,7 +11,7 @@ hero:
     - Alignment & Safety
   subtitle_lines:
     - We are an independent research institute with a mission to
-    - ensure that frontier AI is safe, aligned and open to
+    - ensure that frontier AI is safe, aligned and open for
   beneficiaries:
     - people and society.
     - the people who use it.

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/BaseLayout.astro
 title: The Institute for Ethical AI Alignment & Safety
-description: An independent research institute working to ensure that frontier AI is safe, aligned and accountable to people and society.
+description: An independent research institute working to ensure that frontier AI is safe, aligned and open to people and society.
 hero:
   status: REACH OUT · SUBSCRIBE · APPLY TO JOIN
   status_href: '#join'
@@ -11,7 +11,7 @@ hero:
     - Alignment & Safety
   subtitle_lines:
     - We are an independent research institute with a mission to
-    - ensure that frontier AI is safe, aligned and accountable to
+    - ensure that frontier AI is safe, aligned and open to
   beneficiaries:
     - people and society.
     - the people who use it.


### PR DESCRIPTION
## What

Replaces "accountable" with "open" in the institute's mission caption everywhere it appears, so it now reads **"…ensure that frontier AI is safe, aligned and open to people and society."**

## Why

Accountability is a property of people and institutions, not of AI systems — an AI cannot be held accountable, so the caption was making a claim the technology can't satisfy. "Open" keeps the sentence shape and the rotating hero beneficiaries intact, and carries the institute's openness/open-source identity.

## Changed

- `src/layouts/BaseLayout.astro` — site-wide meta description
- `src/components/FootnoteBand.astro` — footer band text
- `src/pages/index.mdx` — page description + hero subtitle (rotation over beneficiaries unchanged: "…open to people and society / the people who use it / …")
- `src/pages/about.mdx` — page description + mission paragraph

## Deliberately untouched

- "accountable people" in principles 01/09 and the founders line in about.mdx — these correctly refer to humans
- External policy submissions (historical documents)
- Newsletter issue 399 (already sent to subscribers)
- `src/data/contactForm.ts:47` still says "Safe, accountable technology" — same category issue, but different phrasing; flagging for a separate call

Build passes (`npm run build`); text-only change, no structural/style edits.