### PR TITLE
fix(newsletter): restore the issue 400 link to the new phase announcement post

### DIFF
--- a/src/content/newsletter/400.md
+++ b/src/content/newsletter/400.md
@@ -16,7 +16,7 @@ We have come really far since the first newsletter edition in 2018, and today we
 
 Our mission continues to be the same; let's make production machine learning something we can all do well and do responsibly.
 
-Thank you for being part of it, and bring on 400 more! We look forward to continue this great momentum towards [the new phase of the Institute](/newsletter/399/)!
+Thank you for being part of it, and bring on 400 more! We look forward to continue this great momentum towards [the new phase of the Institute](/blog/new-phase-institute-ethical-ai-alignment-safety/)!
 
 ## This week in [ML Engineering](http://ethical.institute/mle/400.html):
 


### PR DESCRIPTION
Restores the closing link in issue 400 to `/blog/new-phase-institute-ethical-ai-alignment-safety/`.

I changed that link to `/newsletter/399/` before merging PR #114, because it returned 404 when I checked it. The 404 was misleading: the issue 400 worktree was branched from master at `57a3002`, which predates PR #116 adding the post, so the post did not exist in that checkout or on the dev server running from it. It was already on master when issue 400 merged.

Verified 200 against a dev server running from current master.

The lesson for the workflow is that a link check run inside a worktree only proves the target is absent from that branch point, not that it is absent from master.