### PR TITLE
feat(events): add AGNTCon + MCPCon Europe and HumanX Amsterdam, confirm code.talks

### DIFF
--- a/src/content/events.yaml
+++ b/src/content/events.yaml
@@ -25,6 +25,9 @@
   cfps:
     - url: https://codetalks.com/call-for-paper
       deadline: 2026-08-31
+  talks:
+    - title: To be announced
+      url: https://codetalks.com/
 
 - slug: world-summit-ai-europe-2026
   name: World Summit AI Europe 2026
@@ -37,6 +40,26 @@
   topics: [ai-agents, ai-policy, llms]
   talks:
     - title: To be announced
+
+- slug: humanx-emea-2026
+  name: HumanX Amsterdam 2026
+  series: humanx-emea
+  url: https://www.humanx.co/europe
+  image: https://www.humanx.co/europe/opengraph-image.png
+  start: 2026-09-22
+  end: 2026-09-24
+  location: Amsterdam, NL
+  topics: [ai-policy, llms, general-tech]
+
+- slug: agntcon-mcpcon-europe-2026
+  name: AGNTCon + MCPCon Europe 2026
+  series: agntcon-mcpcon-europe
+  url: https://events.linuxfoundation.org/agntcon-mcpcon-europe/
+  image: https://events.linuxfoundation.org/wp-content/uploads/2026/04/agntcon-mcpcon-europe-2026-snackable.jpg
+  start: 2026-09-17
+  end: 2026-09-18
+  location: Amsterdam, NL
+  topics: [ai-agents, llms, cloud-native]
 
 - slug: ai-infra-summit-2026
   name: AI Infra Summit 2026


### PR DESCRIPTION
Applies the owner-approved outcomes of the issue 400 events scout.

## Added

| Event | Dates | Venue | CFP |
| --- | --- | --- | --- |
| AGNTCon + MCPCon Europe 2026 | 17-18 Sep 2026 | RAI Amsterdam | Closed 8 Jun |
| HumanX Amsterdam 2026 | 22-24 Sep 2026 | RAI Amsterdam | Curated, no public CFP |

Both are confirmed next editions of `feature`-tier watchlist entries, verified against the organiser pages (and Sessionize for AGNTCon). Banners fetched via `scripts/events/fetch-banners.mjs`.

## Changed

`code-talks-2026` gains a `talks` entry: the talk is confirmed, title still to be announced, following the same convention as World Summit AI Europe and AI Infra Summit. The `cfps` block stays because wave 3 is open to other speakers until 31 August.

## Not included

The scout also proposed dropping both `# unverified` markers on `mlops-world-2026` after confirming 17-18 November via the organiser's live ticketing listing. That proposal has not been approved, so the markers stand.

Sort order verified by parsing the file and comparing against a reverse sort by `start`. `astro check` passes at zero errors, warnings and hints.