### PR TITLE
fix(homepage): derive the newsletter issue count from the collection

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -29,7 +29,8 @@ hero:
 evidence:
   - value: '09'
     label: AI ALIGNMENT & SAFETY PRINCIPLES
-  - value: '393'
+  # Counted from the newsletter collection at build; see the StatBand call below.
+  - value: derived
     label: NEWSLETTER ISSUES PUBLISHED
   - value: 70k+
     label: ML PRACTITIONERS REACHED
@@ -240,6 +241,9 @@ import OpenSourceShowcase from '../components/OpenSourceShowcase.astro';
 import FormSection from '../components/FormSection.astro';
 import PolicySection from '../components/PolicySection.astro';
 import { contactFormCopy, contactFormTitle, networkSectors, networkStats } from '../data/contactForm';
+import { getIssueCount } from '../utils/RecentIssues';
+
+export const issueCount = await getIssueCount();
 
 <script
   type="application/ld+json"
@@ -253,7 +257,7 @@ import { contactFormCopy, contactFormTitle, networkSectors, networkStats } from 
 
 <Hero {...frontmatter.hero} />
 
-<StatBand stats={frontmatter.evidence} />
+<StatBand stats={frontmatter.evidence.map((stat) => (stat.value === 'derived' ? { ...stat, value: `${issueCount}` } : stat))} />
 
 <AffiliationMarquee />
 

--- a/src/utils/RecentIssues.ts
+++ b/src/utils/RecentIssues.ts
@@ -30,3 +30,9 @@ export function toIssueRanges(numbers: number[]) {
     .map(([from, to]) => (from === to ? `${from}` : `${from}-${to}`))
     .join(' ');
 }
+
+// The homepage's "issues published" stat. Counting entries rather than reading the
+// highest number keeps it honest if the archive ever has a gap.
+export async function getIssueCount() {
+  return (await getCollection('newsletter')).length;
+}


### PR DESCRIPTION
The evidence stat band hard-coded 393, stale by seven issues.

Hard-coding a corrected 400 would have been the same mistake with a fresher number: the count changes weekly, so any literal is a promise to remember. `getIssueCount` joins the existing helpers in `src/utils/RecentIssues.ts`, which already reads the newsletter collection elsewhere. It counts entries rather than reading the highest issue number, so an archive gap cannot silently inflate it.

The frontmatter keeps its label and position with `value: derived` as an explicit marker, so the page still owns the copy and the ordering.

Verified against built output rather than a type check: `dist/index.html` renders 400 beside the label.