### PR TITLE
fix(article): drop the stray gap above the sticky meta bar

### DIFF
--- a/STYLES.md
+++ b/STYLES.md
@@ -353,4 +353,4 @@ Use these widths for CSS media queries. A component that needs responsive client
 3. For a new token, add it to `:root` when at least two owners need the same semantic value, or when the value must change between themes. A theme-dependent value is always a token, however few owners it has: a literal has nowhere to flip to under `:root[data-theme='light']`. Otherwise keep the value local.
 4. If an override seems necessary, find the existing owner first and change the original rule or component API. Add a cross-owner rule to `tokens.css` only when the relationship itself is shared and document that reason here.
 
-<!-- styles-hash: 1a79a1b498fc101c94816f0c53f3e0fdb382bbd4cd703fb67266424b1da1296a -->
+<!-- styles-hash: 6dbfbd548dcd532c01925d8f6429a421ff9f51de8e3ad07a7cbade9220b25837 -->

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -191,7 +191,6 @@ const bylineAuthors = entry.data.authors.map((name) => ({ name, anchor: authors[
     display: grid;
     gap: 12px;
     grid-template-columns: minmax(72px, 1fr) auto minmax(72px, 1fr);
-    margin-top: 34px;
     padding: 16px 24px;
   }
   .blog-chips {

--- a/src/pages/newsletter/[issue].astro
+++ b/src/pages/newsletter/[issue].astro
@@ -202,7 +202,6 @@ const frontmatter = {
     display: grid;
     gap: 12px;
     grid-template-columns: minmax(72px, 1fr) auto minmax(72px, 1fr);
-    margin-top: 34px;
     padding: 16px 24px;
     position: sticky;
     top: var(--meta-stuck-top);


### PR DESCRIPTION
The newsletter and blog meta bars each carried `margin-top: 34px`, leaving a 34px strip of `--bg-base` between the hero and a full-bleed band painted in the darker `--bg-inset`, with the band's own top hairline immediately below it. Two separators for one boundary, and the lighter strip read as an unintended seam.

## Why it was there

Vestigial. Before the bar was a band it was a transparent header block whose rule was `padding: 34px 24px 0`, so the 34 was interior spacing. The rework that gave it the inset background, block borders and sticky docking (`6cb038c`) moved that number to `margin-top`, putting it outside the band; the blog meta later inherited the finished newsletter rule verbatim (`bb7a759`).

## What changes

The band now meets the hero directly and its top hairline is the only seam. Nothing else moves:

- The margin never affected the docked pose, since the bar is `position: sticky` with `top: var(--meta-stuck-top)`.
- The 34px above the deck (`.issue-lede`) is a separate rule and still separates the bar from the body.

Measured at 1440: hero bottom to bar top was 34px on both surfaces before, 0px after.

## Verification

- `npm run lint`, `npm run format:check`, `npm run check:ratchet` (`STYLES.md` synced) and `npm run build` pass.
- DOM gate passes on the production build at 1440x1000 and 420x900 for `/blog/whose-memory-is-it-part-2/` and `/newsletter/400/`.
- Before/after captured on both surfaces.

Labelled `visual-change`: every newsletter issue and blog post moves up 34px.