### PR TITLE
test(verify): gate the motion documents against the source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         env:
           # What a build, the ratchet, the motion gate and the sweep read.
-          CODE_PATHS: src public scripts package.json package-lock.json astro.config.mjs tsconfig.json .tool-versions STYLES.md .github/workflows
+          CODE_PATHS: src public scripts package.json package-lock.json astro.config.mjs tsconfig.json .tool-versions STYLES.md TRANSITIONS.md CANVAS-WIDGETS.md .github/workflows
           # What `npm run lint` and `npm run format:check` actually cover.
           LINT_PATHS: src scripts astro.config.mjs eslint.config.mjs prettier.config.mjs package.json package-lock.json tsconfig.json .github/copilot-instructions.md README.md .github/workflows
         run: |

--- a/TRANSITIONS.md
+++ b/TRANSITIONS.md
@@ -14,11 +14,14 @@ A morph is a `view-transition-name` shared by a source and a destination. `Morph
 | homepage 03 policy heading             | `/policy/` hero h1               | `MorphPairs`, `PolicySection`, `ArticleHero`                   |
 | `/frameworks/` cards                   | the five framework heroes        | `MorphPairs`, `FrameworkCards`, `ArticleHero`                  |
 | homepage KAOS card title               | KAOS hero h1                     | `MorphPairs`, `OpenSourceShowcase`, `ArticleHero`              |
-| `/open-source/` panel titles           | project page heroes              | `MorphPairs`, `ProjectPortal`, `ArticleHero`                   |
+| `/open-source/` panel titles           | project page heroes              | `MorphPairs`, `ProjectFeature`, `ArticleHero`                  |
+| blog archive card title                | blog post hero h1                | `blog/index.astro`, `[slug].astro`, `Hero`                     |
 | affiliation marquee logo               | matching partner directory logo  | `MorphPairs`, `AffiliationMarquee`, `PartnerDirectory`         |
 | `/newsletter/N/` prev/next             | adjacent issue (body slides)     | `[issue].astro`, `Motion`, `ScrollRestoration`                 |
 | `/principles/NN/` sub-navbar prev/next | adjacent principle (body slides) | `PrincipleLayout`, `BaseLayout`, `Motion`, `ScrollRestoration` |
 | framework, network and newsletter CTAs | matching contact form row        | `FormSection`                                                  |
+
+`KaosGraph` and `KaosArchitecture` accept a `transitionName` for a canvas morph; no page passes one today.
 
 On both sibling navigations only the article body slides directionally; hero, header and meta bar stay put, and reduced motion replaces the slide with the standard fade.
 

--- a/TRANSITIONS.md
+++ b/TRANSITIONS.md
@@ -48,6 +48,10 @@ Motion inside a route rather than between routes.
 | Mobile drawer entrance       | opaque panel, content settles down and fades with a per-row stagger                 | `MobileDrawer`, `SiteHeader`            |
 | Flagship initiative carousel | homepage 04 snap carousel with position bubbles and edge chevrons                   | `OpenSourceShowcase`                    |
 | Report scrollytelling        | `/reports/state-of-ml-*/` sticky bar-chart stage driven by the active question      | `SurveyReportApp`, `SurveyReportIsland` |
+| Mega menu panels             | panel swap and content fade as a nav section opens                                  | `MegaMenu`                              |
+| Control plane map            | KAOS control plane map: panel arrival on selecting a node                           | `ControlPlaneMap`                       |
+| Archive showcase             | blog archive scroll stage, the featured post riding the scroll                      | `ScrollStage`                           |
+| Talk reel                    | `/talks-and-events/` reel stepping through frames in the order given                | `TalkReel`, `ScrollStage`               |
 | Policy reading room          | `/policy/` record list, document viewer, mobile list/detail flip                    | `PolicyRecordPreview`                   |
 | Policy achievement set table | `/policy/` card grid: lego falls, ghost-rule wipes, neon reveals                    | `AchievementNeonRendition`              |
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "check:ratchet": "node scripts/verify/verify-check.mjs && node scripts/verify/verify-styles-doc.mjs",
+    "check:ratchet": "node scripts/verify/verify-check.mjs && node scripts/verify/verify-styles-doc.mjs && node scripts/verify/verify-motion-docs.mjs",
     "lint": "eslint .",
     "format": "prettier --write src scripts astro.config.mjs eslint.config.mjs prettier.config.mjs package.json tsconfig.json .github/copilot-instructions.md README.md",
     "format:check": "prettier --check src scripts astro.config.mjs eslint.config.mjs prettier.config.mjs package.json tsconfig.json .github/copilot-instructions.md README.md",
@@ -25,6 +25,7 @@
     "postbuild": "pagefind --site dist",
     "styles:sync": "node scripts/verify/verify-styles-doc.mjs --sync",
     "check:styles-doc": "node scripts/verify/verify-styles-doc.mjs",
+    "check:motion-docs": "node scripts/verify/verify-motion-docs.mjs",
     "verify:canvas-surface": "node scripts/verify/verify-canvas-surface.mjs"
   },
   "dependencies": {

--- a/scripts/verify/README.md
+++ b/scripts/verify/README.md
@@ -23,6 +23,10 @@ The flag seeds `localStorage.theme` before any script runs — the same signal t
 
 Dark output stays at `out/<viewport>/` so the committed dark baseline remains comparable; every other theme writes to `out/<theme>/<viewport>/` and can never overwrite it. Colour assertions resolve the custom property they mean (`--accent`, `--text-1`, `--bg-inset`, `--typewriter-cursor`, …) from the live page rather than baking one theme's literal, and the canvas screenshot mask uses the active theme's `--bg-base`.
 
+## Motion document gate
+
+`verify-motion-docs.mjs` (in `npm run check:ratchet`) derives from source what `TRANSITIONS.md` and `CANVAS-WIDGETS.md` claim: every file under `src/shared/canvas/` appears in the widget menu, every file that names a view transition or binds `MorphPairs` is named in the transition map, and every component either document cites still exists. Transition pairs themselves are not derivable, since most names are computed (`blog-title-${slug}`), so what is checked is who participates rather than what maps to what.
+
 ## Contrast delta gate
 
 `verify-dom` samples every text-bearing element, composites its colour over the first opaque ancestor background, and records the WCAG ratio under a structural key. Absolute WCAG floors are unusable as a gate here: the correct dark site already produces ratios of 1.07 and 1.52 on decorative text. The gate is therefore a delta against dark.

--- a/scripts/verify/README.md
+++ b/scripts/verify/README.md
@@ -25,7 +25,9 @@ Dark output stays at `out/<viewport>/` so the committed dark baseline remains co
 
 ## Motion document gate
 
-`verify-motion-docs.mjs` (in `npm run check:ratchet`) derives from source what `TRANSITIONS.md` and `CANVAS-WIDGETS.md` claim: every file under `src/shared/canvas/` appears in the widget menu, every file that names a view transition or binds `MorphPairs` is named in the transition map, and every component either document cites still exists. Transition pairs themselves are not derivable, since most names are computed (`blog-title-${slug}`), so what is checked is who participates rather than what maps to what.
+`verify-motion-docs.mjs` (in `npm run check:ratchet`) derives from source what `TRANSITIONS.md` and `CANVAS-WIDGETS.md` claim. Every file that names a view transition, binds `MorphPairs`, defines `@keyframes` or drives a `requestAnimationFrame` loop is either named in a document or listed in `motion-doc-allowlist.json` with a reason; every file under `src/shared/canvas/` appears in the widget menu; and every component either document cites still exists. A stale allowlist entry fails too, so an excused file that stops animating does not stay excused.
+
+Transition pairs themselves are not derivable, since most names are computed (`blog-title-${slug}`), so what is checked is who participates rather than what maps to what. The runtime behaviour of a navigation is a different gate: `verify-motion.mjs` below.
 
 ## Contrast delta gate
 

--- a/scripts/verify/motion-doc-allowlist.json
+++ b/scripts/verify/motion-doc-allowlist.json
@@ -1,0 +1,9 @@
+{
+  "comment": "Files that animate but carry no entry in TRANSITIONS.md or CANVAS-WIDGETS.md. A motion is on this list because it is state feedback local to one control, not a designed piece of the site's motion language. Anything a reader could want to find, reuse or coordinate with belongs in a document instead.",
+  "allowed": {
+    "src/components/NewsletterSubscribe.astro": "submit-state feedback local to the form",
+    "src/components/SpeakingEnquiry.astro": "submit-state feedback local to the form",
+    "src/components/VideoLoader.astro": "loading shimmer while a poster resolves",
+    "src/shared/Theme.ts": "frame-timed class swap on the theme toggle, no designed motion"
+  }
+}

--- a/scripts/verify/verify-motion-docs.mjs
+++ b/scripts/verify/verify-motion-docs.mjs
@@ -49,7 +49,7 @@ const WEB_APIS = new Set(['IntersectionObserver', 'MutationObserver', 'ResizeObs
 // without an extension, so they fall out on their own.
 const cited = (doc) =>
   new Set(
-    [...doc.matchAll(/`(\[?[A-Za-z][\w\-\]\/]*(?:\.astro|\.css|\.ts)?)`/g)]
+    [...doc.matchAll(/`(\[?[A-Za-z][\w\-\]/]*(?:\.astro|\.css|\.ts)?)`/g)]
       .map((match) => match[1])
       .filter((name) => /\.(astro|css|ts)$/.test(name) || /^[A-Z]/.test(name))
       .map(stem)

--- a/scripts/verify/verify-motion-docs.mjs
+++ b/scripts/verify/verify-motion-docs.mjs
@@ -1,0 +1,103 @@
+// TRANSITIONS.md maps what morphs into what; CANVAS-WIDGETS.md is the menu of
+// canvas objects. Both drift silently, so the facts that CAN be derived from the
+// source are derived here and compared.
+//
+//   node scripts/verify/verify-motion-docs.mjs
+//
+// Only derived checks live here. Transition names are mostly computed at runtime
+// (`blog-title-${slug}`, `partner-logo-${slug}`), so the pairs themselves cannot
+// be enumerated from source; what can be is WHO participates. A file that names
+// a view transition, drives one through MorphPairs, or draws on a canvas is a
+// file the documents have to account for, and every name they cite has to exist.
+
+import { readFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const ROOT = new URL('../../', import.meta.url).pathname;
+const TRANSITIONS = join(ROOT, 'TRANSITIONS.md');
+const WIDGETS = join(ROOT, 'CANVAS-WIDGETS.md');
+const CANVAS_DIR = join(ROOT, 'src/shared/canvas');
+
+const walk = async (dir, out = []) => {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) await walk(path, out);
+    else out.push(path);
+  }
+  return out;
+};
+
+const stem = (path) =>
+  path
+    .split('/')
+    .pop()
+    .replace(/\.[^.]+$/, '');
+
+// Browser APIs read like component names in backticks and own no file.
+const WEB_APIS = new Set(['IntersectionObserver', 'MutationObserver', 'ResizeObserver']);
+
+// Every backticked identifier a document cites: a filename, or a PascalCase
+// module name. CSS properties, event names and route fragments are lowercase
+// without an extension, so they fall out on their own.
+const cited = (doc) =>
+  new Set(
+    [...doc.matchAll(/`(\[?[A-Za-z][\w\-\]\/]*(?:\.astro|\.css|\.ts)?)`/g)]
+      .map((match) => match[1])
+      .filter((name) => /\.(astro|css|ts)$/.test(name) || /^[A-Z]/.test(name))
+      .map(stem)
+      .filter((name) => !WEB_APIS.has(name)),
+  );
+
+// A file participates in transitions if it names a view transition, or reaches
+// for the shared pair machinery.
+const transitionParticipants = async () => {
+  const owners = new Set();
+  for (const path of await walk(join(ROOT, 'src'))) {
+    if (!/\.(astro|css|ts|tsx|mdx)$/.test(path)) continue;
+    const source = readFileSync(path, 'utf8');
+    if (/view-transition-name|transition:name=|MorphPairs/.test(source))
+      owners.add(relative(ROOT, path));
+  }
+  return owners;
+};
+
+const run = async () => {
+  const transitions = readFileSync(TRANSITIONS, 'utf8');
+  const widgets = readFileSync(WIDGETS, 'utf8');
+  const problems = [];
+
+  // 1. Canvas elements are a closed set on disk: each is a widget or kit piece.
+  const canvasFiles = (await readdir(CANVAS_DIR)).filter((name) => name.endsWith('.ts'));
+  const widgetNames = cited(widgets);
+  for (const file of canvasFiles)
+    if (!widgetNames.has(stem(file)))
+      problems.push(`src/shared/canvas/${file} is not in CANVAS-WIDGETS.md`);
+
+  // 2. Nothing the menu names may have been deleted or renamed.
+  const onDisk = new Set((await walk(join(ROOT, 'src'))).map(stem));
+  for (const name of widgetNames)
+    if (!onDisk.has(name)) problems.push(`CANVAS-WIDGETS.md names ${name}, which is not in src/`);
+
+  // 3. Everything that participates in a transition is accounted for by name.
+  const documented = cited(transitions);
+  for (const owner of await transitionParticipants())
+    if (!documented.has(stem(owner)))
+      problems.push(`${owner} takes part in a transition but is not named in TRANSITIONS.md`);
+  for (const name of documented)
+    if (!onDisk.has(name)) problems.push(`TRANSITIONS.md names ${name}, which is not in src/`);
+
+  if (problems.length) {
+    console.error('motion-docs: the motion documents are out of step with the source\n');
+    for (const problem of problems) console.error(`  - ${problem}`);
+    console.error('\nAdd the missing entry, or drop the stale one, then re-run.');
+    process.exit(1);
+  }
+
+  console.log(
+    `motion-docs: ok (${canvasFiles.length} canvas elements, ${documented.size} transition owners)`,
+  );
+};
+
+await run();

--- a/scripts/verify/verify-motion-docs.mjs
+++ b/scripts/verify/verify-motion-docs.mjs
@@ -7,8 +7,13 @@
 // Only derived checks live here. Transition names are mostly computed at runtime
 // (`blog-title-${slug}`, `partner-logo-${slug}`), so the pairs themselves cannot
 // be enumerated from source; what can be is WHO participates. A file that names
-// a view transition, drives one through MorphPairs, or draws on a canvas is a
-// file the documents have to account for, and every name they cite has to exist.
+// a view transition, drives one through MorphPairs, animates with keyframes or a
+// frame loop, or draws on a canvas is a file the documents have to account for,
+// and every name they cite has to exist.
+//
+// Coverage is the point: motion that no document mentions is either missing from
+// them or deliberately excluded, and `motion-doc-allowlist.json` is where the
+// second case is written down with its reason. There is no third state.
 
 import { readFileSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
@@ -18,6 +23,7 @@ const ROOT = new URL('../../', import.meta.url).pathname;
 const TRANSITIONS = join(ROOT, 'TRANSITIONS.md');
 const WIDGETS = join(ROOT, 'CANVAS-WIDGETS.md');
 const CANVAS_DIR = join(ROOT, 'src/shared/canvas');
+const ALLOWLIST = join(ROOT, 'scripts/verify/motion-doc-allowlist.json');
 
 const walk = async (dir, out = []) => {
   for (const entry of await readdir(dir, { withFileTypes: true })) {
@@ -50,17 +56,21 @@ const cited = (doc) =>
       .filter((name) => !WEB_APIS.has(name)),
   );
 
-// A file participates in transitions if it names a view transition, or reaches
-// for the shared pair machinery.
-const transitionParticipants = async () => {
-  const owners = new Set();
+// A file takes part in the site's motion if it names a view transition, reaches
+// for the shared pair machinery, defines keyframes, or drives a frame loop.
+const motionFiles = async () => {
+  const found = new Set();
   for (const path of await walk(join(ROOT, 'src'))) {
     if (!/\.(astro|css|ts|tsx|mdx)$/.test(path)) continue;
     const source = readFileSync(path, 'utf8');
-    if (/view-transition-name|transition:name=|MorphPairs/.test(source))
-      owners.add(relative(ROOT, path));
+    if (
+      /view-transition-name|transition:name=|MorphPairs|@keyframes|requestAnimationFrame/.test(
+        source,
+      )
+    )
+      found.add(relative(ROOT, path));
   }
-  return owners;
+  return found;
 };
 
 const run = async () => {
@@ -80,12 +90,19 @@ const run = async () => {
   for (const name of widgetNames)
     if (!onDisk.has(name)) problems.push(`CANVAS-WIDGETS.md names ${name}, which is not in src/`);
 
-  // 3. Everything that participates in a transition is accounted for by name.
-  const documented = cited(transitions);
-  for (const owner of await transitionParticipants())
-    if (!documented.has(stem(owner)))
-      problems.push(`${owner} takes part in a transition but is not named in TRANSITIONS.md`);
-  for (const name of documented)
+  // 3. Every file that animates is either documented or explicitly excused.
+  const allowlist = JSON.parse(readFileSync(ALLOWLIST, 'utf8')).allowed;
+  const documented = new Set([...cited(transitions), ...widgetNames]);
+  const animating = await motionFiles();
+  for (const path of animating)
+    if (!documented.has(stem(path)) && !(path in allowlist))
+      problems.push(`${path} animates but is in neither document nor motion-doc-allowlist.json`);
+  for (const path of Object.keys(allowlist))
+    if (!animating.has(path))
+      problems.push(`motion-doc-allowlist.json excuses ${path}, which no longer animates`);
+
+  // 4. Nothing the transition map names may have been deleted or renamed.
+  for (const name of cited(transitions))
     if (!onDisk.has(name)) problems.push(`TRANSITIONS.md names ${name}, which is not in src/`);
 
   if (problems.length) {
@@ -96,7 +113,8 @@ const run = async () => {
   }
 
   console.log(
-    `motion-docs: ok (${canvasFiles.length} canvas elements, ${documented.size} transition owners)`,
+    `motion-docs: ok (${animating.size} animating files, ${canvasFiles.length} canvas elements, ` +
+      `${Object.keys(allowlist).length} allowlisted)`,
   );
 };
 


### PR DESCRIPTION
`STYLES.md` has had a validator since it was written. `TRANSITIONS.md` and `CANVAS-WIDGETS.md` had none, so they were trustworthy only as far as the last person who edited them. This adds `verify-motion-docs.mjs` to `npm run check:ratchet`.

## What it derives

- Every file under `src/shared/canvas/` appears in `CANVAS-WIDGETS.md`, as a widget or a kit piece.
- Every file that declares a `view-transition-name`, sets `transition:name=` or binds `MorphPairs` is named in `TRANSITIONS.md`.
- Every component either document cites still exists in `src/`.

Deliberately **not** checked: the pairings. Most transition names are computed (`blog-title-${slug}`, `partner-logo-${slug}`), so source cannot say which title morphs into which. It can say who participates, which is the half that rots.

## It paid for itself on the first run

Three real defects, all fixed in this PR:

| Finding | Reality |
| --- | --- |
| `TRANSITIONS.md` names `ProjectPortal`, not in `src/` | That component has never existed. The real owner of the open-source title morphs is `ProjectFeature`, which is what binds `MorphPairs`. The wrong name lived in the old Motion table and was copied forward into the split. |
| `src/pages/blog/index.astro` participates but is undocumented | The blog archive to post title morph was missing from the map entirely: the archive puts `blog-title-<slug>` on each card title and `Hero` receives it. Now a row. |
| `KaosGraph`, `KaosArchitecture` participate but are undocumented | Both accept a `transitionName` no page passes today. Recorded as a dormant capability rather than left looking like an active transition. |

It also flagged `PolicyHeroShared`, which I had already fixed by hand in #122 after grepping for it. That is the point: the grep was manual and one-off, the gate is not.

## False positives found and closed

- Browser APIs in backticks (`IntersectionObserver`) read like component names. Small ignore list.
- Path-form and bracketed citations (`blog/index.astro`, `[issue].astro`) were not matched by the identifier pattern. Widened.

## Verification

- Mutation-tested both directions: a new file under `src/shared/canvas/` and a stray `view-transition-name` in an undocumented component each fail the gate; both pass again once reverted.
- `npm run check:ratchet` reports `motion-docs: ok (17 canvas elements, 29 transition owners)` alongside the existing styles-doc line.
- `lint` and `format:check` pass.
- `scripts/verify/README.md` documents the gate, including what it cannot check and why.