### PR TITLE
fix(content): correct the Zalando job title to Director of AI, Data & Platform

### DIFF
--- a/src/data/authors.ts
+++ b/src/data/authors.ts
@@ -16,7 +16,7 @@ export const authors: Record<string, Author> = {
     slug: 'alejandro-saucedo',
     name: 'Alejandro Saucedo',
     role: 'Co-founder & Scientific Advisor',
-    bio: 'Co-founder and Scientific Advisor at the Institute, Director of Markets AI, Data & Platform at Zalando SE, appointed AI Expert at the United Nations and Board Member at the ACM.',
+    bio: 'Co-founder and Scientific Advisor at the Institute, Director of AI, Data & Platform at Zalando SE, appointed AI Expert at the United Nations and Board Member at the ACM.',
     aboutAnchor: '/about/#alejandro-saucedo',
     portrait: '/images/people/alejandro-saucedo.jpg',
     affiliation: 'Zalando SE',

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -42,7 +42,7 @@ The Institute is founder-coordinated. Its two founders remain accountable for th
 
 <img src="/images/people/alejandro-saucedo.jpg" alt="Alejandro Saucedo" width="120" loading="lazy" />
 
-Alejandro Saucedo is co-founder and Scientific Advisor at the Institute for Ethical AI Alignment & Safety, where he has led contributions to European policy including the AI Act, the Data Act and the Digital Services Act. He is Director of Markets AI, Data & Platform at Zalando SE, an appointed AI Expert at the United Nations, Board Member at the Association for Computing Machinery (ACM), and visiting lecturer at the Technische Universität München.
+Alejandro Saucedo is co-founder and Scientific Advisor at the Institute for Ethical AI Alignment & Safety, where he has led contributions to European policy including the AI Act, the Data Act and the Digital Services Act. He is Director of AI, Data & Platform at Zalando SE, an appointed AI Expert at the United Nations, Board Member at the Association for Computing Machinery (ACM), and visiting lecturer at the Technische Universität München.
 
 ### Lucy Yu
 


### PR DESCRIPTION
The author bio read "Director of Markets AI, Data & Platform", which is no longer current.

Two occurrences, both describing the same person:

- `src/data/authors.ts`, which feeds article bylines and the Article JSON-LD across newsletter issues and blog posts
- `src/pages/about.mdx` prose

Confirmed by the owner after three variants surfaced across recent correspondence and this repo. The built output carries no occurrence of the old title.

Gates: lint, `astro check` at 0/0/0, production build all pass.