### PR TITLE
feat(seo): submit sitemap URLs to IndexNow after each deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,3 +42,17 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5
+  indexnow:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit sitemap URLs to IndexNow
+        run: |
+          key=1c243c5ba8b5dda1cf01e6c1730e4e63
+          curl -sf https://ethical.institute/sitemap-0.xml \
+            | grep -o '<loc>[^<]*' | sed 's/<loc>//' \
+            | jq -R . | jq -s --arg key "$key" \
+                '{host: "ethical.institute", key: $key, keyLocation: ("https://ethical.institute/" + $key + ".txt"), urlList: .}' \
+            | curl -sS -X POST https://api.indexnow.org/indexnow \
+                -H 'Content-Type: application/json; charset=utf-8' \
+                --data-binary @- -o /dev/null -w 'IndexNow HTTP %{http_code}\n'

--- a/public/1c243c5ba8b5dda1cf01e6c1730e4e63.txt
+++ b/public/1c243c5ba8b5dda1cf01e6c1730e4e63.txt
@@ -1,0 +1,1 @@
+1c243c5ba8b5dda1cf01e6c1730e4e63


### PR DESCRIPTION
## What

Adds IndexNow support, addressing the red recommendation in Bing Webmaster Tools.

- `public/1c243c5ba8b5dda1cf01e6c1730e4e63.txt` — the IndexNow key file, served at the site root. IndexNow keys are public by design (ownership is verified by fetching this exact file), so committing it is safe.
- New `indexnow` job in `deploy.yml`, running after the Pages deployment: fetches the live `sitemap-0.xml`, extracts all URLs (currently 441; protocol limit is 10,000 per request) and POSTs them to `api.indexnow.org` in a single request, logging the HTTP status.

## Why

Bing (and Yandex/Seznam/Naver) get pinged at publish time instead of waiting for crawl discovery — this matters most for the weekly newsletter issues and new blog posts. Google does not use IndexNow; it is unaffected.

## Notes

- Submitting the full sitemap on each deploy is the simple, stateless option; the site is small and deploys are at most a few per day (push + daily cron), well within protocol norms.
- The step fetches the sitemap from the live site right after deploy; a transient CDN miss would fail the job visibly (`curl -f`) without affecting the already-completed deployment — rerunning the job resubmits.
- No runtime code and no third-party fetches on the site itself; redirect stubs and prototypes are not in the sitemap so are never submitted.

## Verification

Dry-ran the payload pipeline locally against the live sitemap: valid JSON, `host`/`key`/`keyLocation` correct, 441 URLs, first `https://ethical.institute/`, last `https://ethical.institute/talks-and-events/`. The actual POST will first run on the deploy after merge; the job log shows `IndexNow HTTP <code>` (200/202 = accepted).