### PR TITLE
docs(voice): one shared voice core for blog and newsletter, and extend check:voice to issues

### DIFF
--- a/.claude/rules/voice.md
+++ b/.claude/rules/voice.md
@@ -1,0 +1,1 @@
+../../.github/instructions/voice.instructions.md

--- a/.claude/skills/newsletter-issue/SKILL.md
+++ b/.claude/skills/newsletter-issue/SKILL.md
@@ -72,7 +72,7 @@ When a source survives every tier unread, stop on that article: leave its `TODO 
 
 ## 4. Draft the five sections
 
-Read `references/style.md` in full. Then write one paragraph per article, ordered hook first, substance in slots 2 to 4, lighter closer last.
+Read `.github/instructions/voice.instructions.md` and `references/style.md`, both in full. The first is the shared core the blog and the newsletter both obey; the second is the newsletter's own shape and register, and it never relaxes the first. Then write one paragraph per article, ordered hook first, substance in slots 2 to 4, lighter closer last.
 
 Headings are short editorial rewrites of three to six words, not the source's own title, often `<Actor> on <Thing>` ("Netflix on the LLM-Native RecSys"). Each wraps its whole title in one link. Step 6 joins them into the summary, so write them to read well in a list.
 
@@ -81,7 +81,7 @@ Constraints, all from `references/style.md`:
 - About 789 words of article prose across the issue, with real variance between sections. The median section is 158 words and the corpus runs 31 to 291; five sections near 160 is more uniform than anything published.
 - Roughly three of five sections open on a colon-lede, the rest on a short exclamation or question.
 - Exclamation marks and semicolons belong mid-paragraph, not only in the opener: about four or five of each per issue.
-- No bullets, no sub-headings, no second link to a source already in its heading, none of the banned words.
+- No bullets, no sub-headings, no second link to a source already in its heading, none of the banned words or constructions.
 - Close every section on an editorial beat.
 - Attribute claims to the source ("they claim", "OpenAI estimates") rather than asserting vendor numbers as fact.
 
@@ -110,6 +110,7 @@ You can also find our upcoming events and past talk recordings on the [talks and
 ```
 node scripts/newsletter/style-corpus.mjs --lint src/content/newsletter/<N>.md
 npx prettier --write src/content/newsletter/<N>.md
+npm run check:voice
 npm run check
 ```
 

--- a/.claude/skills/newsletter-issue/references/style.md
+++ b/.claude/skills/newsletter-issue/references/style.md
@@ -1,5 +1,9 @@
 # Newsletter voice
 
+Read `.github/instructions/voice.instructions.md` first. It is the shared core for both blog and newsletter prose: personification, sentence shape, no superfluous text, banned constructions and banned words. It applies to every issue from 402 on, and nothing below relaxes it.
+
+This file is the newsletter's own structure and register, which the shared core does not cover and does not override.
+
 Mined from issues 359-398 (198 article sections) by `scripts/newsletter/style-corpus.mjs`. Regenerate with `node scripts/newsletter/style-corpus.mjs --issues 40` and re-curate this file when the voice drifts.
 
 Keep the window at 40 issues. Over the full 398-issue archive the colon-lede rate falls from 58% to 27% and the median section halves from 158 to 70 words: the current voice is recent, and mining the whole archive teaches the wrong one.
@@ -20,6 +24,8 @@ Per issue: 5 sections, 789 words and 29 sentences of article prose in total.
 ## The lede
 
 58% of sections open with a scene-setting first sentence that ends in a colon, then the detail follows. This is the single strongest structural tell of the voice.
+
+The blog bans mid-prose apposition after a colon ("The rule is simple: ..."), where the second half restates the first. This is not that: the lede names the actor and the release, and the colon introduces the detail that follows, which is the use every guide permits. Do not "fix" a lede into a single sentence.
 
 > Netflix has developed an LLM-native Recommender System, and they share some of the learnings they gathered along the journey:
 
@@ -83,7 +89,11 @@ Hedges are load-bearing, not filler. Use them: `it seems that` 13/10 · `seems t
 
 ## Never
 
-These appear zero times in 198 sections. Writing any of them breaks the voice instantly: `delve`, `game-changing`, `revolutionary`, `pivotal`, `testament`, `crucial`, `moreover`, `furthermore`. Near-zero and only in technical senses: `seamless` 2, `landscape` 2, `leverage` 4, `unlock` 7, `harness` 9 (always "agent harness"), `robust` 11.
+The shared core's banned word list holds, and every word on it is already absent or near-absent from the corpus. Three of them need a newsletter reading:
+
+- `harness` is allowed as a noun, because the newsletter reports on agent harnesses by name ("DeepSeek's Agent Harness"). The verb is not.
+- `journey` and `showcase` are banned in the prose. Their handful of corpus uses are a talk title and a product's own page name, which the "unless quoting a source, a title or a product name" exception already covers.
+- `leverage` (4 uses) and the near-zero `seamless`, `landscape` and `robust` stay banned or near-banned. `unlock` (7) is not banned anywhere and stays available.
 
 Also never: bullets inside an article section; a second link to the source already linked in the heading; a summary sentence that restates the heading; "In this article the authors".
 

--- a/.github/instructions/blog.instructions.md
+++ b/.github/instructions/blog.instructions.md
@@ -19,45 +19,19 @@ Posts live as `src/content/blog/<YYYY-MM-DD->slug/index.md` with colocated asset
 
 ## Voice
 
-Blog prose is written in the author's voice, extracted from the published archive (the higher-altitude post, the memory series). Every sentence must add knowledge; a sentence that only emphasises or restates the previous point is deleted.
+`voice.instructions.md` holds the shared core: personification, sentence shape, no superfluous text, word choice, banned constructions, banned words and the calibration pairs. Apply it in full. What follows is blog-only, and adds to it rather than relaxing it.
 
-No superfluous text. Make each point once, in the sentence where it lives, and move on:
-
-- No bullet list that elaborates the benefits of a point already made in prose; the author deletes these wholesale.
-- No justification sentence appended after a stated practice ("We put the machine on format checking because it does that job better..."). State the practice; the reader can infer why.
-- One example or consequence where the draft piles up three ("how software gets built, how research gets summarised and how decisions get drafted" became "how software gets built").
-- No trailing amplifier clause ("...without being rewritten for either", "...and the risk goes away") and no closing sentence that repeats the section's point.
-- Added words must carry new facts, motive or a concrete example ("as we don't aim for this to be a complete list of skills, but a curated list").
+Blog prose is written in the author's voice, extracted from the published archive (the higher-altitude post, the memory series).
 
 Section titles are in Title Case and carry the section's claim, question or finding, never an abstract category label. From the archive: "Task State Is Not Memory", "What Changes When the Loop Keeps Running?", "When NOT to Add Long-Term Memory", "Memory 101: The Version Everyone Starts With", "Kubernetes Enters the Picture: Memory as Infrastructure", "Access Scopes: Whose Memory Is It Anyway?". Numbered patterns carry series ("Decision 1:", "Failure 1:", "Step 1:", "Surprise #1:"), colon constructions and playful titles are welcome, and "Closing Thoughts" ends a post. A title like "The objective" or "Overview" says nothing and gets replaced.
 
-The single strongest driver is **personification**. The author is present in the text as "I" (personal posts) or "we" (Institute posts), and actions have actors: "we make sure every change runs the validator", never "every change runs the validator". This applies to headings too ("What we are shipping today", not "What ships today"). A paragraph with no person in it is almost always the detached LLM register.
+Structure and register:
 
-Sentence shape is the second driver, and it has two failure modes that both read as LLM:
-
-- Chopping one thought into consecutive short declarative fragments ("A plugin is the unit an assistant installs. That is the only packaging layer."). Fold the fragment into the sentence it belongs to or delete it. A short sentence is fine when it carries a complete plain thought; a fragment that restates or punctuates the previous sentence is not.
-- Fusing several thoughts into one nested sentence ("A skill writes that same capability down as a folder with a SKILL.md at its root, which holds a short description the agent matches against the task in front of it and the procedure it should follow once it matches."). Sentences read in normal order (subject, verb, object), one thought per clause. Length comes from chaining plain clauses with "and", "so", "but", "as" or "because", never from stacking relative clauses or piling modifiers. At most one subordinate clause per sentence; if the reader has to re-read to find who does what, split it.
-
-Other register rules:
-
-- Conversational questions and interjections are fine ("Well, which one is it?"); declarative punch fragments that close or restate a point are not.
-- Prefer common words. Do not reach for a vivid uncommon verb ("evaporates") when a plain phrase does the job ("is ephemeral", "disappears").
-- Write numbers as digits (600), not spelled out (six hundred).
-- Ground claims in experience with inline parenthetical examples, "etc" welcome: "After many iterations building and using skills, I found the sweet spot by using deterministic scripts where the actions are clear (carrying out auth, executing against an API, etc), and leaning on non-deterministic intelligence where the task benefits from logic (something not working, building a creative structure like a document or deck, etc)." That sentence replaced "I believe this balance is what a skill gets you, and finding it is a craft in itself. You want deterministic utilities where the answer is fixed..." - the difference is the pattern.
-- Use contractions naturally ("wasn't", "it's", "I've").
-- Casual hedges and colloquial fillers are part of the register ("just", "a bunch of", "pretty much", "nowadays", "organically").
-- Colons only introduce lists, enumerations or code blocks; mid-prose apposition ("The rule is simple: ...") gets merged into one sentence instead.
+- Colons only introduce lists, enumerations or code blocks; mid-prose apposition ("The rule is simple: ...") gets merged into one sentence instead. The newsletter's colon-lede is a different move and is not a precedent here.
 - Bullet points are normal sentences that start with a capital and end with a full stop. Never comma-separated fragments continuing the lead-in sentence ("- the architecture section,").
-- Avoid definitional framings without an actor ("X is the unit that...", "X serves as..."); say what someone does with the thing.
-
-Calibration pairs from the author (left is the tell, right is the voice):
-
-- "Not as a decision; it just happened." -> "It wasn't an explicit decision I made, it just happened organically."
-- "Ask an agent to write you a skill and it will hand back something impressive and wrong." -> "Whenever I blindly delegate the skill writing to an agent, I end up getting a bunch of AI slop; it ends up being more of a menu of suggestions than an actual recipe."
-- "Which makes it worth being precise about how to write one, because the default is bad." -> "Being precise about how to write one is important nowadays because the default is just not great."
-- "Every change runs scripts/validate.sh in CI." -> "We make sure that every change runs scripts/validate.sh in CI."
-- "Five skills across three plugins. Each of them is a tool we use." -> "Each of the five skills we are shipping is a tool we use in our own day-to-day work."
-- "A skill writes that same capability down as a folder with a SKILL.md at its root, which holds a short description the agent matches against the task in front of it and the procedure it should follow once it matches." -> "A skill writes that same capability down as a folder with a SKILL.md file at its root. The file holds a short description and a procedure. The agent matches the description against the task in front of it, and once it matches, it follows the procedure."
+- Conversational questions and interjections are fine ("Well, which one is it?"); declarative punch fragments that close or restate a point are not.
+- Also banned here, on top of the shared list: ship/shipping (write release, publish, or land), which reads as marketing when the author is describing his own work.
+- Do not overuse `-` dashes or boldface. Bold is for coined terms and genuinely load-bearing phrases.
 
 What the posts do:
 
@@ -67,24 +41,3 @@ What the posts do:
 - Stay concrete with real project names, tool lists and numbers, and generalise only after the specific case.
 - Pull quotes are practical or playful, never sonorous epigrams.
 - Personable asides ("In my opinion...", light humour, self-deprecation) at most once per section, and most sections have none.
-
-Banned constructions (LLM tells):
-
-- "It's not X. It's Y." / "Not just X, but Y" / negative parallelisms; "the real X is"; "is less X, and more Y"; "X rather than Y" framed as misconception-correction.
-- "is quietly ...", "Delving into", "At its core", "it rarely survives", "this is another strong signal that ... moving from ... into ...".
-- Aphorism pull quotes; mic-drop one-line paragraph closers; chiasmus and inversion snaps.
-- Runs of symmetric bolded-lead bullets ("**Portable, not captive.** ... **Reviewable as text.** ...").
-- Sentences ending in a trailing "-ing" commentary clause ("...highlighting the importance of X").
-- Copula avoidance ("serves as", "stands as", "functions as", "marks"): write "is".
-- Metaphor equations ("Context is the budget, and the skill spends it..."). Say the plain fact instead.
-- A follow-up sentence that labels the previous one ("This is progressive disclosure."). Fold the term in ("An example of progressive disclosure is when...").
-- Gerund equations of the form "X is Y, and doing-Z means W" ("A script does one thing, and extending it means reopening it."). Cryptic and hard to parse; say it plainly or delete it.
-- Abstract throat-clearing paragraph openers that frame the point before making it ("Being precise about how to write one is important nowadays because..."). Open the paragraph with the point itself.
-- Symmetric wrap-up clauses tacked onto a finished sentence ("...so each side does the job the other is bad at."). The sentence was done; end it.
-- The rule of three as a reflex; vague attribution ("experts argue") without a named source.
-
-Banned words unless quoting a source: testament, underscore, propel, unwavering, heartfelt, embrace, foster, ignite, empower, amplify, catalyst, leverage, epitome, cornerstone, harness, noteworthy, unprecedented, profound, pivotal, journey, delve, crucial, tapestry, showcase, vibrant, groundbreaking, "diverse array", "failure modes" (write "common failures"), ship/shipping (write release, publish, or land). Use plain alternatives: shows, indicates, supports, argues.
-
-Punctuation: the site-wide ASCII rules already ban em dashes and curly quotes; additionally, do not overuse `-` dashes or boldface. Bold is for coined terms and genuinely load-bearing phrases.
-
-Enforcement: `scripts/verify/check-voice.sh` runs in the lint CI job (`npm run check:voice`, gated on blog/newsletter content changes) and fails the build only on the zero-judgement cases: non-ASCII characters and a short list of words and phrases that never appear in legitimate prose. Everything else in this section - the full banned lists, sentence shape, personification, superfluous text, section titles - cannot be grepped without false positives and is enforced by this file alone: these are strict requirements, not suggestions, and every agent writing or editing a post must apply them in full.

--- a/.github/instructions/voice.instructions.md
+++ b/.github/instructions/voice.instructions.md
@@ -1,0 +1,84 @@
+---
+applyTo: '{src/content/blog/**,src/content/newsletter/**}'
+paths:
+  - 'src/content/blog/**'
+  - 'src/content/newsletter/**'
+---
+
+# Shared prose voice
+
+The rules every authored article obeys, in both media. They exist because the default LLM register produces prose the owner deletes wholesale.
+
+Medium-specific structure lives beside this file: `blog.instructions.md` for posts, and the `newsletter-issue` skill's `references/style.md` for issues. Those two own section shape, headings, ledes, bullets and register. They never relax the banned lists here.
+
+## Personification
+
+The single strongest driver. The author is present as "I" (personal) or "we" (Institute), and actions have actors: "we make sure every change runs the validator", never "every change runs the validator". This applies to headings too ("What we are shipping today", not "What ships today"). A paragraph with no person in it is almost always the detached LLM register.
+
+Avoid definitional framings without an actor ("X is the unit that...", "X serves as..."); say what someone does with the thing.
+
+## Sentence shape
+
+Two failure modes, both of which read as LLM:
+
+- Chopping one thought into consecutive short declarative fragments ("A plugin is the unit an assistant installs. That is the only packaging layer."). Fold the fragment into the sentence it belongs to or delete it. A short sentence is fine when it carries a complete plain thought; a fragment that restates or punctuates the previous sentence is not.
+- Fusing several thoughts into one nested sentence ("A skill writes that same capability down as a folder with a SKILL.md at its root, which holds a short description the agent matches against the task in front of it and the procedure it should follow once it matches."). Sentences read in normal order (subject, verb, object), one thought per clause. Length comes from chaining plain clauses with "and", "so", "but", "as" or "because", never from stacking relative clauses or piling modifiers. At most one subordinate clause per sentence; if the reader has to re-read to find who does what, split it.
+
+## No superfluous text
+
+Every sentence must add knowledge; a sentence that only emphasises or restates the previous point is deleted. Make each point once, in the sentence where it lives, and move on:
+
+- No bullet list that elaborates the benefits of a point already made in prose.
+- No justification sentence appended after a stated practice ("We put the machine on format checking because it does that job better..."). State the practice; the reader can infer why.
+- One example or consequence where the draft piles up three ("how software gets built, how research gets summarised and how decisions get drafted" became "how software gets built").
+- No trailing amplifier clause ("...without being rewritten for either", "...and the risk goes away") and no closing sentence that repeats the section's point.
+- Added words must carry new facts, motive or a concrete example ("as we don't aim for this to be a complete list of skills, but a curated list").
+
+## Word choice
+
+- Prefer common words. Do not reach for a vivid uncommon verb ("evaporates") when a plain phrase does the job ("is ephemeral", "disappears").
+- Write numbers as digits (600), not spelled out (six hundred).
+- Use contractions naturally ("wasn't", "it's", "I've").
+- Casual hedges and colloquial fillers are part of the register ("just", "a bunch of", "pretty much", "nowadays", "organically"). They are load-bearing, not filler.
+- Ground claims in experience or in the source, with inline parenthetical examples, "etc" welcome. Attribute rather than assert ("they claim", "OpenAI estimates").
+
+## Banned constructions (LLM tells)
+
+- "It's not X. It's Y." / "Not just X, but Y" / negative parallelisms; "the real X is"; "is less X, and more Y"; "X rather than Y" framed as misconception-correction.
+- "is quietly ...", "Delving into", "At its core", "it rarely survives", "this is another strong signal that ... moving from ... into ...".
+- Aphorism pull quotes; mic-drop one-line paragraph closers; chiasmus and inversion snaps.
+- Runs of symmetric bolded-lead bullets ("**Portable, not captive.** ... **Reviewable as text.** ...").
+- Sentences ending in a trailing "-ing" commentary clause ("...highlighting the importance of X").
+- Copula avoidance ("serves as", "stands as", "functions as", "marks"): write "is".
+- Metaphor equations ("Context is the budget, and the skill spends it..."). Say the plain fact instead.
+- A follow-up sentence that labels the previous one ("This is progressive disclosure."). Fold the term in ("An example of progressive disclosure is when...").
+- Gerund equations of the form "X is Y, and doing-Z means W" ("A script does one thing, and extending it means reopening it."). Cryptic and hard to parse; say it plainly or delete it.
+- Abstract throat-clearing paragraph openers that frame the point before making it ("Being precise about how to write one is important nowadays because..."). Open with the point itself.
+- Symmetric wrap-up clauses tacked onto a finished sentence ("...so each side does the job the other is bad at."). The sentence was done; end it.
+- The rule of three as a reflex; vague attribution ("experts argue") without a named source.
+- A summary sentence that restates the heading; "In this article the authors".
+
+## Banned words
+
+Unless quoting a source, a title or a product name: testament, underscore, propel, unwavering, heartfelt, embrace, foster, ignite, empower, amplify, catalyst, leverage, epitome, cornerstone, noteworthy, unprecedented, profound, pivotal, journey, delve, crucial, tapestry, showcase, vibrant, groundbreaking, revolutionary, "game-changing", "diverse array", "failure modes" (write "common failures"), moreover, furthermore. Use plain alternatives: shows, indicates, supports, argues, use.
+
+Near-zero in the archive, so never a staple: seamless, landscape, robust.
+
+`harness` is allowed only as a noun for the technical object ("agent harness", "the harness they use"), which is what the newsletter reports on every few weeks. The verb ("harness the power of") is banned.
+
+## Calibration pairs
+
+Left is the tell, right is the voice:
+
+- "Not as a decision; it just happened." -> "It wasn't an explicit decision I made, it just happened organically."
+- "Ask an agent to write you a skill and it will hand back something impressive and wrong." -> "Whenever I blindly delegate the skill writing to an agent, I end up getting a bunch of AI slop; it ends up being more of a menu of suggestions than an actual recipe."
+- "Which makes it worth being precise about how to write one, because the default is bad." -> "Being precise about how to write one is important nowadays because the default is just not great."
+- "Every change runs scripts/validate.sh in CI." -> "We make sure that every change runs scripts/validate.sh in CI."
+- "Five skills across three plugins. Each of them is a tool we use." -> "Each of the five skills we are shipping is a tool we use in our own day-to-day work."
+- "A skill writes that same capability down as a folder with a SKILL.md at its root, which holds a short description the agent matches against the task in front of it and the procedure it should follow once it matches." -> "A skill writes that same capability down as a folder with a SKILL.md file at its root. The file holds a short description and a procedure. The agent matches the description against the task in front of it, and once it matches, it follows the procedure."
+
+## Enforcement
+
+`scripts/verify/check-voice.sh` (`npm run check:voice`) runs in the lint CI job whenever `src/content/blog` or `src/content/newsletter` changed. It fails only on the zero-judgement cases: a short list of words and phrases that never appear in legitimate prose, and the non-ASCII punctuation the site-wide rule bans. It reads blog posts dated on or after 2026-08-29 and newsletter issues from 402 on; earlier work predates this guide and is not retro-edited.
+
+Everything else here cannot be grepped without false positives and is enforced by this file alone. These are strict requirements, not suggestions, and every agent writing or editing an article must apply them in full.

--- a/scripts/verify/check-voice.sh
+++ b/scripts/verify/check-voice.sh
@@ -1,43 +1,71 @@
 #!/usr/bin/env bash
-# Mechanical voice checks for blog posts: non-ASCII characters (em dashes,
-# curly quotes, ellipses) and a short list of words and phrases that
-# essentially never appear in legitimate prose. Everything requiring judgement
-# lives in .github/instructions/blog.instructions.md and is applied by the
-# agent writing the post, not here.
+# Mechanical voice checks for blog posts and newsletter issues: a short list of
+# words and phrases that essentially never appear in legitimate prose, plus the
+# non-ASCII punctuation the site-wide rule bans. Everything requiring judgement
+# lives in .github/instructions/voice.instructions.md and is applied by the
+# agent writing the article, not here.
 #
-# Posts dated before the voice guide existed (2026-08-29) are skipped rather
-# than retro-edited.
+# Work written before the voice guide existed is skipped rather than
+# retro-edited: blog posts dated before 2026-08-29, and newsletter issues
+# below 402.
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/../.." && pwd)"
-cutoff='2026-08-29'
+blog_cutoff='2026-08-29'
+issue_cutoff=402
 
-words='testament|tapestry|delv(e|es|ed|ing)|epitome|cornerstone|unwavering|heartfelt|groundbreaking|diverse array'
+words='testament|tapestry|delv(e|es|ed|ing)|epitome|cornerstone|unwavering|heartfelt|groundbreaking|revolutionary|pivotal|moreover|furthermore|diverse array|game-changing'
 phrases='is quietly|at its core|it rarely survives'
 
+# Written as an alternation of literal characters rather than a bracket
+# expression so it matches the exact UTF-8 byte sequences whatever locale the
+# runner has: en dash, em dash, curly quotes, ellipsis.
+punctuation='–|—|‘|’|“|”|…'
+
 status=0
-for file in "$root"/src/content/blog/*/index.md; do
-  date="$(awk '/^---$/{f++} f==1 && sub(/^date: */, ""){print; exit}' "$file")"
-  if [ -z "$date" ] || [[ "$date" < "$cutoff" ]]; then
-    continue
-  fi
+
+report() {
+  echo "$1 in $2:"
+  echo "$3"
+  status=1
+}
+
+# $1 is the file, $2 the pattern for the non-ASCII check.
+check() {
+  local file="$1" ascii_pattern="$2" relative matches
   relative="${file#"$root/"}"
   if matches="$(grep -inEw "$words" "$file")"; then
-    echo "BANNED WORD in $relative:"
-    echo "$matches"
-    status=1
+    report 'BANNED WORD' "$relative" "$matches"
   fi
   if matches="$(grep -inE "$phrases" "$file")"; then
-    echo "BANNED PHRASE in $relative:"
-    echo "$matches"
-    status=1
+    report 'BANNED PHRASE' "$relative" "$matches"
   fi
-  if matches="$(LC_ALL=C grep -n '[^	 -~]' "$file")"; then
-    echo "NON-ASCII in $relative:"
-    echo "$matches"
-    status=1
+  if matches="$(LC_ALL=C grep -nE "$ascii_pattern" "$file")"; then
+    report 'NON-ASCII' "$relative" "$matches"
   fi
+}
+
+# A blog post has no legitimate use for any non-ASCII character, so its arm keeps
+# the blanket check.
+for file in "$root"/src/content/blog/*/index.md; do
+  date="$(awk '/^---$/{f++} f==1 && sub(/^date: */, ""){print; exit}' "$file")"
+  if [ -z "$date" ] || [[ "$date" < "$blog_cutoff" ]]; then
+    continue
+  fi
+  check "$file" '[^	 -~]'
 done
 
-[ "$status" -eq 0 ] && echo "OK: blog voice checks passed"
+# The newsletter cannot use the blanket check: emoji are content there. The
+# boilerplate alone carries 🚀 ⭐ 🤖 ✉️ 🐦 💼 📕, and headings and summaries add
+# more. So this arm checks only the characters the ASCII punctuation rule exists
+# to catch.
+for file in "$root"/src/content/newsletter/*.md; do
+  issue="$(basename "$file" .md)"
+  if [ "$issue" -lt "$issue_cutoff" ]; then
+    continue
+  fi
+  check "$file" "$punctuation"
+done
+
+[ "$status" -eq 0 ] && echo "OK: voice checks passed"
 exit "$status"


### PR DESCRIPTION
## What

The blog's voice guide and the newsletter's mined style doc were written independently, so the LLM tells the blog bans outright were unenforced in the newsletter, and the banned word lists were about to drift apart in two files.

- **New `.github/instructions/voice.instructions.md`** - the shared core, applying to `src/content/blog/**` and `src/content/newsletter/**`, symlinked from `.claude/rules/voice.md`. Personification, sentence shape, no superfluous text, word choice, banned constructions, banned words, calibration pairs.
- **`blog.instructions.md`** keeps only blog-specific rules: Title Case claim headings, the colon rule, bullet shape, what the posts do, the ship/shipping ban.
- **`references/style.md`** keeps only the newsletter's measured shape and register, and points at the core first.

No list is duplicated across the two.

## Word-list conflicts

| Word | Newsletter evidence | Resolution |
| --- | --- | --- |
| `harness` | 9 uses, always the noun, often a proper name ("DeepSeek's Agent Harness") | Noun allowed, verb banned |
| `journey` | 4 uses: a talk title, a corpus quote, an anniversary aside | Banned; the quoting exception covers the title |
| `showcase` | 1 use, Streamlit's own page name | Banned; same exception |
| `leverage` | 4 uses in 40 issues | Banned; "use" always substitutes |
| `unlock` | 7 uses | Never banned anywhere; stays available |
| `revolutionary`, `game-changing`, `moreover`, `furthermore` | 0 uses | Added to the shared core and to the mechanical check |

The **colon-lede is preserved explicitly**, with the reason. At 58% of sections it is the strongest structural tell of the voice, and it is the permitted colon use (the lede introduces the detail that follows), not the mid-prose apposition the blog merges.

## The check

`check-voice.sh` now reads newsletter issues from 402 on, mirroring the blog's `2026-08-29` cutoff so 359-401 are not retro-edited. The two arms differ on one check: the blog keeps the blanket non-ASCII grep; the newsletter cannot use it, because emoji are content there, so it greps for en dash, em dash, curly quotes and the ellipsis character as an alternation of literal characters that matches the same UTF-8 bytes in any locale.

Verified: fails on each violation injected into a scratch issue (banned word, `moreover`, em dash, curly quote, ellipsis) and on a blog post with an em dash; passes on emoji-only content, on 402 as published, on a pre-cutoff issue carrying deliberate violations, and on the tree as it stands.

`npm run check:voice`, `npm run lint`, `npm run format:check` and `npm run check` pass. `node scripts/newsletter/style-corpus.mjs --lint src/content/newsletter/402.md` still reports the same 1 known error and 1 warning, both left standing. No published prose was edited.