### PR TITLE
feat(events): track the 35th Economic Forum in Karpacz

### DIFF
--- a/src/content/events.yaml
+++ b/src/content/events.yaml
@@ -83,6 +83,15 @@
   talks:
     - title: To be announced
 
+- slug: economic-forum-2026
+  name: Economic Forum 2026
+  series: economic-forum
+  url: https://www.forum-ekonomiczne.pl/en
+  start: 2026-09-08
+  end: 2026-09-10
+  location: Karpacz, PL
+  topics: [ai-policy, general-tech, llms]
+
 - slug: euroscipy-2026
   name: EuroSciPy 2026
   series: euroscipy


### PR DESCRIPTION
Adds the 35th Economic Forum to the tracked events.

**Event.** 8-10 September 2026, Hotel Golebiewski, Karpacz, PL. Largest socio-economic conference in Central Europe; this edition runs AI and cybersecurity tracks under the theme "Architecture of the New Order - Stability in Times of Change". Organisers expect 6,000+ participants from ~60 countries.

**Two judgement calls worth a look:**

- No `talks` entry. The yaml's convention is that `talks` is present only where we appear on a programme, and attending is not speaking. If a slot is confirmed, add one.
- No `image`. The organiser serves both the page and its og image behind a 403 to non-browser clients, so `fetch-banners.mjs` cannot take one and the generated SVG banner is used instead.

Dates are from the organiser's own programme PDF and Polish-language announcement, not a listing aggregator.

Sorted into position by `start`, newest first, between Signals Conference (09-10) and EuroSciPy (07-18). `npm run lint` and `npm run check` (0/0/0) pass.