### PR TITLE
chore(events): add three approved 2027 flagships and track FastAPI Conf

### DIFF
--- a/scripts/events/data/scout-ledger.yaml
+++ b/scripts/events/data/scout-ledger.yaml
@@ -43,6 +43,8 @@ watchlist:
     - name: MLOps World
       note: US, unique flagship in the MLOps niche - standing exception; moved Austin to SF
   cfp-track:
+    - name: FastAPI Conf
+      note: official FastAPI-team event, Amsterdam; first edition invited-speakers only, watch for a real CFP
     - name: Rise of AI Berlin
       note: ~300 curated seats, German-ecosystem lineup; attend because Berlin
     - name: Accelerate Tomorrow AI Summit Berlin
@@ -77,7 +79,7 @@ scouted:
     next_edition: 2027-03-15 to 2027-03-18, Barcelona, ES
     cfp: OPEN - opened 2026-08-10, closes 2026-10-11 23:59 CEST (https://sessionize.com/kubecon-cloudnativecon-europe-2027/)
     owner: keen to submit - CFP now open, flagged in issue-401 scout report
-    note: proposed into events.yaml on 2026-08-23; proposal still not merged as of 2026-09-06
+    note: added to events.yaml on 2026-09-06
   - name: AGNTCon + MCPCon Europe
     url: https://events.linuxfoundation.org/agntcon-mcpcon-europe/
     checked: 2026-08-16
@@ -143,7 +145,7 @@ scouted:
     status: tracked
     next_edition: 2027-06-29 to 2027-07-02, Moscone West, San Francisco, US - confirmed on organiser site
     cfp: not open yet (no speaker call visible 2026-08-23)
-    note: proposed into events.yaml on 2026-08-23; proposal still not merged as of 2026-09-06
+    note: added to events.yaml on 2026-09-06
   - name: MLOps World
     url: https://mlopsworld.com/call-for-speakers/
     checked: 2026-09-06

--- a/src/content/events.yaml
+++ b/src/content/events.yaml
@@ -3,6 +3,29 @@
 # One event is one conference: several talks or several per-track CFPs live in the arrays.
 # Sorted by `start`, newest first.
 
+- slug: wearedevelopers-world-congress-2027
+  name: WeAreDevelopers World Congress 2027
+  series: wearedevelopers-world-congress
+  url: https://www.wearedevelopers.com/world-congress
+  image: https://imagedelivery.net/p2Gwf4g3bNtyXUmnEu9Kdw/main-stage/main-stage-panorama/og?format=auto
+  start: 2027-07-14
+  end: 2027-07-16
+  location: Berlin, DE
+  topics: [general-tech, llms]
+  cfps:
+    - url: https://sessionize.com/wearedevelopers-world-congress-2026-europe/
+      # no deadline: the official call has closed, late submissions are rolling
+
+- slug: ai-engineer-worlds-fair-2027
+  name: AI Engineer World's Fair 2027
+  series: ai-engineer-worlds-fair
+  url: https://ai.engineer/
+  image: https://ai.engineer/og-image-ai-engineer.png
+  start: 2027-06-29
+  end: 2027-07-02
+  location: San Francisco, US
+  topics: [ai-agents, llms]
+
 - slug: mlsys-2027
   name: MLSys 2027
   series: mlsys
@@ -13,6 +36,19 @@
   cfps:
     - url: https://openreview.net/group?id=MLSys.org/2027/Conference
       # no deadline announced yet
+
+- slug: kubecon-cloudnativecon-europe-2027
+  name: KubeCon + CloudNativeCon Europe 2027
+  series: kubecon-cloudnativecon-europe
+  url: https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2027/
+  image: https://events.linuxfoundation.org/wp-content/uploads/2024/11/KubeCon-EU27_Snackable.jpg
+  start: 2027-03-15
+  end: 2027-03-18
+  location: Barcelona, ES
+  topics: [cloud-native, mlops, ai-infrastructure]
+  cfps:
+    - url: https://sessionize.com/kubecon-cloudnativecon-europe-2027/
+      deadline: 2026-10-11
 
 - slug: mlops-world-2026
   name: MLOps World 2026


### PR DESCRIPTION
Applies the event decisions from the issue 403 scout run.

## Added to `events.yaml`

| Event | Dates | Location | CFP |
| --- | --- | --- | --- |
| KubeCon + CloudNativeCon Europe 2027 | 15-18 Mar 2027 | Barcelona, ES | open, closes 2026-10-11 |
| AI Engineer World's Fair 2027 | 29 Jun - 2 Jul 2027 | San Francisco, US | not open yet |
| WeAreDevelopers World Congress 2027 | 14-16 Jul 2027 | Berlin, DE | official call closed, late submissions roll via Sessionize |

KubeCon and AI Engineer World's Fair were proposed on 2026-08-23 and re-flagged as pending on every scout run since. Nothing was blocking them technically: each proposal needs its own explicit approval before being applied, and neither had one until now.

All three resolved a banner, and the sort by `start` newest first is preserved.

## Ledger

FastAPI Conf joins `cfp-track` rather than `events.yaml`: first edition, one day, one track, Amsterdam, invited speakers only and no CFP, which is the same community tier as PyCon DE and EuroPython. Tracking it means the second edition gets reassessed if it opens a call.

The three applied proposals had their pending notes updated so future runs stop re-flagging them.

## Deliberately unchanged

MLOps World 2026 keeps its `# unverified` dates. The organiser page, its own Eventbrite listing and the current entry disagree three ways on the end date, so no winner was picked.

`npm run check` passes.