### PR TITLE
fix(newsletter): record walks headed, skip the root load, and dismiss signup modals

### DIFF
--- a/scripts/newsletter/capture-flow.mjs
+++ b/scripts/newsletter/capture-flow.mjs
@@ -22,7 +22,21 @@ export default async function flow({ goto, mark, page, pause, scrollTo }) {
   await goto(process.env.CAPTURE_TARGET_URL);
   mark('article');
 
+  // Third-party articles interrupt a scroll with a newsletter or signup modal
+  // (Medium does it partway down), which then sits over the body for the rest of
+  // the walk. Escape closes every one seen so far, and costs nothing on a page
+  // that has none, so it is pressed at each beat rather than only on arrival.
+  const dismiss = async () => {
+    await page.keyboard.press('Escape').catch(() => {});
+    await page
+      .locator('[aria-label="close" i], button[data-testid="close-button"]')
+      .first()
+      .click({ timeout: 700 })
+      .catch(() => {});
+  };
+
   await pause(1600);
+  await dismiss();
   mark('top');
 
   const depth = await page.evaluate(() => {
@@ -36,6 +50,7 @@ export default async function flow({ goto, mark, page, pause, scrollTo }) {
 
   if (depth > 200) {
     await scrollTo(depth);
+    await dismiss();
     await pause(1500);
     mark('body');
     await scrollTo(0);

--- a/scripts/newsletter/capture-gifs.mjs
+++ b/scripts/newsletter/capture-gifs.mjs
@@ -238,6 +238,13 @@ async function capture(target, { engine, postsDir, theme, workDir }) {
     'node',
     [
       engine,
+      // Headed because headless Chromium is fingerprinted and blocked outright by
+      // some of the sites the newsletter links, and --no-root because the engine
+      // otherwise loads the site root first: wasted footage the runner trims, and
+      // on a Cloudflare-fronted site the root-then-deep-link hop is itself what
+      // trips the bot check.
+      '--headed',
+      '--no-root',
       '--url',
       target.url,
       '--flow',


### PR DESCRIPTION
Two of five articles in issue 403 could not be recorded at all, and the one that did record captured the wrong thing. All three failures were in how the walk reaches and holds the page.

Depends on https://github.com/EthicalML/agent-skills-marketplace/pull/16, which adds `--no-root` and the tolerant root load to the site-capture engine. Merge and update the plugin before this lands, or the flags are ignored.

## Headless was blocked

Same URL, same navigation, differing only in mode:

| Mode | Result |
| --- | --- |
| headless | `"Attention Required! \| Cloudflare"` |
| headed | the real article |

## The root hop was also blocked

The engine loads the site root before handing over to the flow. On a Cloudflare-fronted site that hop is itself what trips the bot check:

| Navigation | Result |
| --- | --- |
| direct to article | the real article |
| root, then article | `"Attention Required! \| Cloudflare"` |

`--no-root` skips it, which also removes footage the runner only trimmed back off.

## Medium covers the article mid-scroll

The first recording that got through captured the article and then a Medium signup modal, which appears partway down a scroll and sits over the body for the rest of the walk. The flow now presses Escape and clicks a close control at each beat rather than only on arrival, since the modal appears on scroll rather than on load. It costs nothing on a page that has none.

## Verification

Frames extracted from the recording rather than trusting the beat log, which only proves the script ran. The Netflix walk now shows article body throughout, with no modal.

## Still failing

`openai.com` serves its own "This page couldn't load" error to the automation browser regardless of these flags. That article needs a still image or a hand-recorded clip; nothing here fixes it.